### PR TITLE
Feat : 전체 식당 목록 카테고리 별 조회 기능 구현

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
@@ -1,9 +1,39 @@
 package org.team.b6.catchtable.domain.store.controller
 
+import org.springframework.data.domain.Sort
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
+import org.team.b6.catchtable.domain.store.model.Store
+import org.team.b6.catchtable.domain.store.service.StoreService
 
 @RestController
 @RequestMapping("/stores")
-class StoreController {
+class StoreController(
+    private val storeService: StoreService
+) {
+    @GetMapping("/{category}")
+    fun findAllStoresByCategory(@PathVariable category: String) =
+        ResponseEntity.ok().body(storeService.findAllStoresByCategory(category))
+
+    @GetMapping("/{category}/sorted")
+    fun findAllStoresByCategoryWithSortCriteria(
+        @PathVariable category: String,
+        @RequestParam direction: Sort.Direction,
+        @RequestParam criteria: String
+    ) =
+        ResponseEntity.ok().body(
+            storeService.findAllStoresByCategoryWithSortCriteria(category, direction, criteria)
+        )
+
+    @PostMapping("")
+    fun register(@RequestBody storeRequest: StoreRequest): Store {
+        return storeService.register(storeRequest)
+    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
@@ -31,9 +31,4 @@ class StoreController(
         ResponseEntity.ok().body(
             storeService.findAllStoresByCategoryWithSortCriteria(category, direction, criteria)
         )
-
-    @PostMapping("")
-    fun register(@RequestBody storeRequest: StoreRequest): Store {
-        return storeService.register(storeRequest)
-    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
@@ -5,10 +5,10 @@ import org.team.b6.catchtable.domain.store.model.StoreCategory
 
 data class StoreRequest(
     val name: String,
-    val category: StoreCategory,
+    val category: String,
     val description: String,
     val phone: String,
     val address: String
 ) {
-    fun to() = Store(name, category, description, phone, address)
+    fun to() = Store(name, StoreCategory.valueOf(category), description, phone, address)
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/response/StoreResponse.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/response/StoreResponse.kt
@@ -1,5 +1,6 @@
 package org.team.b6.catchtable.domain.store.dto.response
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import org.team.b6.catchtable.domain.store.model.Store
 import org.team.b6.catchtable.domain.store.model.StoreCategory
 import java.time.LocalDateTime
@@ -10,6 +11,7 @@ data class StoreResponse(
     val description: String,
     val phone: String,
     val address: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     val createdAt: LocalDateTime
 ) {
     companion object {

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreCategory.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreCategory.kt
@@ -1,5 +1,5 @@
 package org.team.b6.catchtable.domain.store.model
 
 enum class StoreCategory {
-    한식, 일식, 중식, 양식, 디저트, 패스트푸드
+    KOREAN, JAPANESE, CHINESE, ITALIAN, DESSERT, FASTFOOD
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/repository/StoreRepository.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/repository/StoreRepository.kt
@@ -1,8 +1,13 @@
 package org.team.b6.catchtable.domain.store.repository
 
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import org.team.b6.catchtable.domain.store.model.Store
+import org.team.b6.catchtable.domain.store.model.StoreCategory
 
 @Repository
-interface StoreRepository : JpaRepository<Store, Long>
+interface StoreRepository : JpaRepository<Store, Long> {
+    fun findAllByCategory(category: StoreCategory): List<Store>
+    fun findAllByCategory(category: StoreCategory, sort: Sort): List<Store>
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -13,8 +13,6 @@ import org.team.b6.catchtable.domain.store.repository.StoreRepository
 class StoreService(
     private val storeRepository: StoreRepository
 ) {
-    fun register(request: StoreRequest) = storeRepository.save(request.to())
-
     fun findAllStoresByCategory(category: String) =
         storeRepository.findAllByCategory(
             category = getCategory(category)

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -1,7 +1,11 @@
 package org.team.b6.catchtable.domain.store.service
 
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
+import org.team.b6.catchtable.domain.store.dto.response.StoreResponse
+import org.team.b6.catchtable.domain.store.model.StoreCategory
 import org.team.b6.catchtable.domain.store.repository.StoreRepository
 
 @Service
@@ -9,4 +13,24 @@ import org.team.b6.catchtable.domain.store.repository.StoreRepository
 class StoreService(
     private val storeRepository: StoreRepository
 ) {
+    fun register(request: StoreRequest) = storeRepository.save(request.to())
+
+    fun findAllStoresByCategory(category: String) =
+        storeRepository.findAllByCategory(
+            category = getCategory(category)
+        ).map { StoreResponse.from(it) }
+
+    fun findAllStoresByCategoryWithSortCriteria(category: String, direction: Sort.Direction, criteria: String) =
+        storeRepository.findAllByCategory(
+            category = getCategory(category),
+            sort = Sort.by(direction, getCriteria(criteria))
+        ).map { StoreResponse.from(it) }
+
+    private fun getCategory(category: String) =
+        StoreCategory.entries.firstOrNull { it.name == category.uppercase() }
+            ?: throw Exception("TEMP") // TODO : 추후 적용
+
+    private fun getCriteria(criteria: String) =
+        arrayListOf("name").firstOrNull { it == criteria } // TODO: 정렬 조건 추후 추가
+            ?: throw Exception("TEMP") // TODO: 추후 적용
 }


### PR DESCRIPTION
## 연관된 이슈

#5 

## 작업 내용

- [ ] 식당 목록을 category 별로 전체 조회
    - StoreController와 StoreService에 findAllStoresByCategory 메서드 생성
    - StoreService 내에 category를 검증하는 getCategory 내부 메서드 생성
- [ ] 식당 목록을 category + 기타 정렬 조건을 통해 전체 조회
    - StoreController와 StoreService에 findAllStoresByCategoryWithSortCriteria 메서드 생성
    - StoreService 내에 criteria를 검증하는 getCriteria 내부 메서드 생성
- [ ] StoreRepository에 2개의 findAllByCategory 메서드 생성 (메서드 오버라이딩)
    - 하나는 카테고리 별 조회, 나머지는 카테고리 + 정렬 조건으로 조회
- [ ] 예외 처리를 서비스 단에서 실시하기 위해 StoreRequest의 category를 문자열로 받음
    - 추후 to메서드를 통해 엔티티로 변환할 때 StoreCategory enum class 자료형으로 변환
- [ ] StoreResponse의 createdAt 속성을 yyyy-MM-dd 형태로 리턴

## 리뷰 요구사항 (선택)

예외 처리는 추후에 진행할 예정입니다.
