### PR TITLE
[Feat] 멤버 전체 목록 조회 및 개별 조회, password 인코딩

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
@@ -1,9 +1,15 @@
 package org.team.b6.catchtable.domain.member.controller
 
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.team.b6.catchtable.domain.member.dto.response.MemberResponse
+import org.team.b6.catchtable.domain.member.service.MemberService
 
 @RequestMapping("/members")
-class MemberController() {
+class MemberController(
+    val memberService: MemberService
+) {
 
 
     fun signup(){
@@ -22,12 +28,20 @@ class MemberController() {
         TODO()
     }
 
-    fun getMemberList(){
-        TODO()
+    @GetMapping
+    fun getMemberList(): ResponseEntity<List<MemberResponse>>{
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.getMemberList())
     }
 
-    fun getMember(){
-        TODO()
+    @GetMapping("/{memberId}")
+    fun getMember(
+        @PathVariable memberId: Long
+    ): ResponseEntity<MemberResponse?>{
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.getMember(memberId))
     }
 
     //fun logout(){}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/MemberResponse.kt
@@ -1,24 +1,26 @@
 package org.team.b6.catchtable.domain.member.dto.response
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import org.team.b6.catchtable.domain.member.model.Member
 import org.team.b6.catchtable.domain.member.model.MemberRole
 import java.time.LocalDateTime
 
 data class MemberResponse(
-    //회원가입시 response
     val role: MemberRole,
     val nickname: String,
     val name: String,
     val email: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.mm.dd", timezone = "Asia/Seoul")
     val createAt: LocalDateTime
 )
 {
-    companion object
-    fun from(member: Member) = MemberResponse (
-        role = member.role,
-        nickname = member.nickname,
-        name = member.name,
-        email = member.email,
-        createAt = member.createdAt,
-    )
+    companion object {
+        fun from(member: Member) = MemberResponse(
+            role = member.role,
+            nickname = member.nickname,
+            name = member.name,
+            email = member.email,
+            createAt = member.createdAt,
+        )
+    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
@@ -1,13 +1,27 @@
 package org.team.b6.catchtable.domain.member.service
 
+import org.springframework.boot.fromApplication
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.team.b6.catchtable.domain.member.dto.response.MemberResponse
+import org.team.b6.catchtable.domain.member.model.Member
 import org.team.b6.catchtable.domain.member.repository.MemberRepository
 
 @Service
-//@Transactional
+@Transactional
 class MemberService(
     private val memberRepository: MemberRepository,
 ) {
+    fun getMemberList(): List<MemberResponse>{
+        val memberList = memberRepository.findAll().map { MemberResponse.from(it) }
+        return memberList
+    }
 
+    fun getMember(id: Long): MemberResponse {
+        val foundMember =  memberRepository.findByIdOrNull(id)
+            ?: throw Exception("Temp")
+        return MemberResponse.from(foundMember)
+       }
 }
+

--- a/src/main/kotlin/org/team/b6/catchtable/global/security/PasswordEncoderConfig.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/security/PasswordEncoderConfig.kt
@@ -1,0 +1,16 @@
+package org.team.b6.catchtable.global.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+
+
+@Configuration
+class PasswordEncoderConfig {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> #12 

## 작업 내용

- [ ] 멤버 목록을 menberId를 이용해 전체 조회 및 개별 조회
MemberController와 MemberService에 getMemberList를 생성
개별은 getMember로 생성
- [ ] logIn 기능을 위한 password 인코딩 구현
- [ ] MemberResponse의 createdAt 속성을 yyyy-MM-dd 형태로 리턴

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
