### PR TITLE
Feat: Store의 등록/변경/삭제를 위한 중간 엔티티 생성

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
@@ -1,0 +1,21 @@
+package org.team.b6.catchtable.domain.member.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.team.b6.catchtable.domain.member.service.AdminService
+
+@RestController
+@RequestMapping("/admins")
+class AdminController(
+    private val adminService: AdminService
+) {
+    @GetMapping("/stores")
+    fun findAllStoreRequirements() =
+        ResponseEntity.ok().body(adminService.findAllStoreRequirements())
+
+    @PostMapping("/stores/{storeRequirementId}")
+    fun acceptStoreRequirement(@PathVariable storeRequirementId: Long) =
+        ResponseEntity.ok().body(adminService.acceptStoreRequirement(storeRequirementId))
+
+    // TODO: declineStoreRequest 메서드 추후 생성
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/AdminResponse.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/AdminResponse.kt
@@ -1,0 +1,21 @@
+package org.team.b6.catchtable.domain.member.dto.response
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import org.team.b6.catchtable.domain.store.dto.response.StoreResponse
+import org.team.b6.catchtable.domain.store.model.StoreRequirement
+import java.time.LocalDateTime
+
+data class AdminResponse(
+    val requirement: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    val createdAt: LocalDateTime,
+    val store: StoreResponse
+) {
+    companion object {
+        fun from(storeRequirement: StoreRequirement) = AdminResponse(
+            requirement = storeRequirement.requirement.name,
+            createdAt = storeRequirement.createdAt,
+            store = StoreResponse.from(storeRequirement.store!!)
+        )
+    }
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -1,0 +1,35 @@
+package org.team.b6.catchtable.domain.member.service
+
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.team.b6.catchtable.domain.store.model.StoreRequirementCategory
+import org.team.b6.catchtable.domain.store.repository.StoreRequirementRepository
+import org.team.b6.catchtable.domain.store.service.StoreService
+
+@Service
+@Transactional
+class AdminService(
+    private val storeService: StoreService,
+    private val storeRequirementRepository: StoreRequirementRepository
+) {
+    fun findAllStoreRequirements() =
+        storeRequirementRepository.findAll().filter { !it.isAccepted }
+
+    fun acceptStoreRequirement(storeRequirementId: Long) {
+        getStoreRequirement(storeRequirementId)
+            .let {
+                when (it.requirement) {
+                    StoreRequirementCategory.CREATE -> TODO()
+                    StoreRequirementCategory.UPDATE -> TODO()
+                    StoreRequirementCategory.DELETE -> TODO()
+                }
+            }.run { deleteStoreRequirement(storeRequirementId) }
+    }
+
+    private fun deleteStoreRequirement(storeChangeId: Long) =
+        storeRequirementRepository.deleteById(storeChangeId)
+
+    private fun getStoreRequirement(storeChangeId: Long) =
+        storeRequirementRepository.findByIdOrNull(storeChangeId) ?: throw Exception("") // TODO : 추후 구현
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -3,6 +3,7 @@ package org.team.b6.catchtable.domain.member.service
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.team.b6.catchtable.domain.member.dto.response.AdminResponse
 import org.team.b6.catchtable.domain.store.model.StoreRequirementCategory
 import org.team.b6.catchtable.domain.store.repository.StoreRequirementRepository
 import org.team.b6.catchtable.domain.store.service.StoreService
@@ -14,7 +15,7 @@ class AdminService(
     private val storeRequirementRepository: StoreRequirementRepository
 ) {
     fun findAllStoreRequirements() =
-        storeRequirementRepository.findAll().filter { !it.isAccepted }
+        storeRequirementRepository.findAll().filter { !it.isAccepted }.map { AdminResponse.from(it) }
 
     fun acceptStoreRequirement(storeRequirementId: Long) {
         getStoreRequirement(storeRequirementId)

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
@@ -4,19 +4,17 @@ import org.springframework.data.domain.Sort
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
-import org.team.b6.catchtable.domain.store.model.Store
+import org.team.b6.catchtable.domain.store.service.StoreRequirementService
 import org.team.b6.catchtable.domain.store.service.StoreService
 
 @RestController
 @RequestMapping("/stores")
 class StoreController(
-    private val storeService: StoreService
+    private val storeService: StoreService,
+    private val storeRequirementService: StoreRequirementService
 ) {
     @GetMapping("/{category}")
     fun findAllStoresByCategory(@PathVariable category: String) =
@@ -31,4 +29,6 @@ class StoreController(
         ResponseEntity.ok().body(
             storeService.findAllStoresByCategoryWithSortCriteria(category, direction, criteria)
         )
+
+    // TODO: 향후 추가/수정/삭제 메서드 구현시 storeRequirementService를 호출
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
@@ -23,11 +23,6 @@ data class StoreRequest(
 
     fun to(requirement: StoreRequirementCategory, store: Store?) = StoreRequirement(
         requirement = requirement,
-        name = name,
-        category = StoreCategory.valueOf(category),
-        description = description,
-        phone = phone,
-        address = address,
         store = store,
         createdAt = LocalDateTime.now()
     )

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
@@ -2,6 +2,9 @@ package org.team.b6.catchtable.domain.store.dto.request
 
 import org.team.b6.catchtable.domain.store.model.Store
 import org.team.b6.catchtable.domain.store.model.StoreCategory
+import org.team.b6.catchtable.domain.store.model.StoreRequirement
+import org.team.b6.catchtable.domain.store.model.StoreRequirementCategory
+import java.time.LocalDateTime
 
 data class StoreRequest(
     val name: String,
@@ -10,5 +13,22 @@ data class StoreRequest(
     val phone: String,
     val address: String
 ) {
-    fun to() = Store(name, StoreCategory.valueOf(category), description, phone, address)
+    fun to() = Store(
+        name = name,
+        category = StoreCategory.valueOf(category),
+        description = description,
+        phone = phone,
+        address = address
+    )
+
+    fun to(requirement: StoreRequirementCategory, store: Store?) = StoreRequirement(
+        requirement = requirement,
+        name = name,
+        category = StoreCategory.valueOf(category),
+        description = description,
+        phone = phone,
+        address = address,
+        store = store,
+        createdAt = LocalDateTime.now()
+    )
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
@@ -13,7 +13,7 @@ class StoreRequirement(
     @Column(name = "is_accepted", nullable = false)
     var isAccepted: Boolean = false,
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(name = "store_id")
     val store: Store?,
 

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
@@ -1,0 +1,43 @@
+package org.team.b6.catchtable.domain.store.model
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "StoreRequirements")
+class StoreRequirement(
+    @Column(name = "requirement", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val requirement: StoreRequirementCategory,
+
+    @Column(name = "is_accepted", nullable = false)
+    var isAccepted: Boolean = false,
+
+    @Column(name = "name", nullable = false)
+    val name: String? = null,
+
+    @Column(name = "category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val category: StoreCategory? = null,
+
+    @Column(name = "description", nullable = false)
+    val description: String? = null,
+
+    @Column(name = "phone", nullable = false)
+    val phone: String? = null,
+
+    @Column(name = "address", nullable = false)
+    val address: String? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "store_id")
+    val store: Store?,
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    val createdAt: LocalDateTime
+) {
+    @Id
+    @Column(name = "store_requirement_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
@@ -13,22 +13,6 @@ class StoreRequirement(
     @Column(name = "is_accepted", nullable = false)
     var isAccepted: Boolean = false,
 
-    @Column(name = "name", nullable = false)
-    val name: String? = null,
-
-    @Column(name = "category", nullable = false)
-    @Enumerated(EnumType.STRING)
-    val category: StoreCategory? = null,
-
-    @Column(name = "description", nullable = false)
-    val description: String? = null,
-
-    @Column(name = "phone", nullable = false)
-    val phone: String? = null,
-
-    @Column(name = "address", nullable = false)
-    val address: String? = null,
-
     @ManyToOne
     @JoinColumn(name = "store_id")
     val store: Store?,

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirementCategory.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirementCategory.kt
@@ -1,0 +1,5 @@
+package org.team.b6.catchtable.domain.store.model
+
+enum class StoreRequirementCategory {
+    CREATE, UPDATE, DELETE
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/repository/StoreRequirementRepository.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/repository/StoreRequirementRepository.kt
@@ -1,0 +1,9 @@
+package org.team.b6.catchtable.domain.store.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import org.team.b6.catchtable.domain.store.model.StoreRequirement
+
+@Repository
+interface StoreRequirementRepository : JpaRepository<StoreRequirement, Long> {
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
@@ -20,7 +20,7 @@ class StoreRequirementService(
         storeRequirementRepository.save(
             storeRequest.to(
                 requirement = StoreRequirementCategory.CREATE,
-                store = storeRequest.to(),
+                store = storeRequest.to()
             )
         )
     }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
@@ -1,0 +1,49 @@
+package org.team.b6.catchtable.domain.store.service
+
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
+import org.team.b6.catchtable.domain.store.model.StoreRequirement
+import org.team.b6.catchtable.domain.store.model.StoreRequirementCategory
+import org.team.b6.catchtable.domain.store.repository.StoreRequirementRepository
+import org.team.b6.catchtable.domain.store.repository.StoreRepository
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class StoreRequirementService(
+    private val storeRepository: StoreRepository,
+    private val storeRequirementRepository: StoreRequirementRepository
+) {
+    fun applyForRegister(storeRequest: StoreRequest) {
+        storeRequirementRepository.save(
+            storeRequest.to(
+                requirement = StoreRequirementCategory.CREATE,
+                store = null
+            )
+        )
+    }
+
+    fun applyForUpdate(storeId: Long, storeRequest: StoreRequest) {
+        storeRequirementRepository.save(
+            storeRequest.to(
+                requirement = StoreRequirementCategory.UPDATE,
+                store = getStore(storeId)
+            )
+        )
+    }
+
+    fun applyForDelete(storeId: Long) {
+        storeRequirementRepository.save(
+            StoreRequirement(
+                requirement = StoreRequirementCategory.DELETE,
+                store = getStore(storeId),
+                createdAt = LocalDateTime.now()
+            )
+        )
+    }
+
+    private fun getStore(storeId: Long) =
+        storeRepository.findByIdOrNull(storeId) ?: throw Exception("")
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
@@ -20,7 +20,7 @@ class StoreRequirementService(
         storeRequirementRepository.save(
             storeRequest.to(
                 requirement = StoreRequirementCategory.CREATE,
-                store = null
+                store = storeRequest.to(),
             )
         )
     }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -3,7 +3,6 @@ package org.team.b6.catchtable.domain.store.service
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
 import org.team.b6.catchtable.domain.store.dto.response.StoreResponse
 import org.team.b6.catchtable.domain.store.model.StoreCategory
 import org.team.b6.catchtable.domain.store.repository.StoreRepository


### PR DESCRIPTION
## 연관된 이슈

#14

## 작업 내용

## 어떤 기능인가요?
Store에 대한 등록/변경/삭제를 하기전 ADMIN의 승인이 필요하기 때문에, 요청이 바로 StoreRepository에 저장되면 안된다. 따라서, 중간 엔티티인 StoreRequirement를 만들어서, OWNER는 StoreRequirement로 요청을 보내고, ADMIN은 StoreRequirement 요청을 확인하고 승인/거절하는 로직으로 변경하였다.

## 작업 상세 내용
- [ ] Store의 등록/변경/삭제 요청을 담는 StoreRequirement 엔티티 생성
- [ ] Store와 StoreRequirement 사이에 연관관계 설정 (1:n 단방향)
- [ ] StoreRequirementService, StoreRequirementController 클래스 생성
- [ ] StoreController에서 등록/변경/삭제 요청을 받으면 StoreRequirementService의 applyFor... 메서드를 호출
        (기존에는 StoreService로 바로 request를 넘겨주는 방식)

- [ ] AdminController, AdminService 클래스 생성
- [ ] (ADMIN의 승인/거절을 대기 중인) StoreRequirement 전체 목록을 조회하는 findAllStoreRequirements 메서드 생성
- [ ] Store에 대한 등록/변경/삭제 여부를 ADMIN이 승인하는 acceptStoreRequirement 메서드 생성
- [ ] AdminService 클래스 내에 deleteStoreRequirement와 getStoreRequirement 내부 메서드 생성
- [ ] 요청에 대한 승인/거절 시, StoreService의 등록/변경/삭제 관련 메서드를 실행
- [ ] 요청 승인이 완료되면 해당 storeRequirement 삭제

## 리뷰 요구사항 (선택)

엔티티를 아예 새로 하나 만든거라 유심히 봐주세요!