### PR TITLE
feat : 회원가입기능 추가

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
@@ -3,6 +3,9 @@ package org.team.b6.catchtable.domain.member.controller
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.team.b6.catchtable.domain.member.dto.request.LoginRequest
+import org.team.b6.catchtable.domain.member.dto.request.SignupMemberRequest
+import org.team.b6.catchtable.domain.member.dto.response.LoginResponse
 import org.team.b6.catchtable.domain.member.dto.response.MemberResponse
 import org.team.b6.catchtable.domain.member.service.MemberService
 
@@ -12,13 +15,18 @@ class MemberController(
     val memberService: MemberService
 ) {
 
-
-    fun signup(){
-        TODO()
+    @PostMapping("/signup")
+    fun signup(@RequestBody signupMemberRequest: SignupMemberRequest): ResponseEntity<MemberResponse>{
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.signUp(signupMemberRequest))
     }
 
-    fun login(){
-        TODO()
+    @PostMapping("/login")
+    fun login(@RequestBody loginRequest: LoginRequest ): ResponseEntity<LoginResponse>{
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.login(loginRequest))
     }
 
     fun emailCheck(){

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/SignupMemberRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/SignupMemberRequest.kt
@@ -4,12 +4,11 @@ import org.team.b6.catchtable.domain.member.model.Member
 import org.team.b6.catchtable.domain.member.model.MemberRole
 
 data class SignupMemberRequest(
-    val role: MemberRole,
+    val role: String?,
     val nickname: String,
     val name: String,
     val email: String,
     val password: String,
-)
-{
-    fun to()= Member(role,nickname,name,email,password)
+) {
+    //fun to() = Member(MemberRole.valueOf(role), nickname, name, email, password)
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/MemberResponse.kt
@@ -12,8 +12,7 @@ data class MemberResponse(
     val email: String,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.mm.dd", timezone = "Asia/Seoul")
     val createAt: LocalDateTime
-)
-{
+) {
     companion object {
         fun from(member: Member) = MemberResponse(
             role = member.role,

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/repository/MemberRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.team.b6.catchtable.domain.member.model.Member
 
 interface MemberRepository : JpaRepository<Member,Long> {
+    fun findByEmail(email: String): Member?
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
@@ -2,26 +2,64 @@ package org.team.b6.catchtable.domain.member.service
 
 import org.springframework.boot.fromApplication
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.team.b6.catchtable.domain.member.dto.request.LoginRequest
+import org.team.b6.catchtable.domain.member.dto.request.SignupMemberRequest
+import org.team.b6.catchtable.domain.member.dto.response.LoginResponse
 import org.team.b6.catchtable.domain.member.dto.response.MemberResponse
 import org.team.b6.catchtable.domain.member.model.Member
+import org.team.b6.catchtable.domain.member.model.MemberRole
 import org.team.b6.catchtable.domain.member.repository.MemberRepository
 
 @Service
 @Transactional
 class MemberService(
     private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
 ) {
-    fun getMemberList(): List<MemberResponse>{
+
+    fun signUp(request: SignupMemberRequest): MemberResponse {
+
+        return memberRepository.save(
+            Member(
+                email = request.email,
+                nickname = request.nickname,
+                name = request.name,
+                password = passwordEncoder.encode(request.password),
+                role = when (request.role) {
+                    "USER" -> MemberRole.USER
+                    "OWNER" -> MemberRole.OWNER
+                    else -> throw Exception("Temp")
+                }
+            )
+        ).let { MemberResponse.from(it) }
+    }
+
+    fun login(request: LoginRequest): LoginResponse {
+        val member = memberRepository.findByEmail(request.email) ?: throw Exception("Temp")
+        if (member.role.name != request.role || !passwordEncoder.matches(request.password, member.password))
+            throw Exception("Temp")
+
+        return LoginResponse(
+            email = member.email,
+            role = member.role.name,
+            name = member.name,
+            nickname = member.nickname
+        )
+    }
+
+
+    fun getMemberList(): List<MemberResponse> {
         val memberList = memberRepository.findAll().map { MemberResponse.from(it) }
         return memberList
     }
 
     fun getMember(id: Long): MemberResponse {
-        val foundMember =  memberRepository.findByIdOrNull(id)
+        val foundMember = memberRepository.findByIdOrNull(id)
             ?: throw Exception("Temp")
         return MemberResponse.from(foundMember)
-       }
+    }
 }
 


### PR DESCRIPTION

## 연관된 이슈

#20 

## 작업 내용
- [ ] MemberService에서 회원가입을 담당하는 signUp() 메소드를 작성했습니다.
when문을 사용하여 USER,OWNER 이외의 입력은 throw Exception하게 구현했습니다.(Exception은 추후 작성예정)
- [ ] SignupMemberRequest의 Role을 String?로 변경했습니다.
 트러블슈팅하며 수정하긴 했는데, 크게 상관은 없어 변경 가능성 높음
- [ ] MemberResponse는 컨벤션수정했습니다.
- [ ] MemberRepository에 findByEmail() 메소드작성
 로그인 메소드 구현시에 사용할 예정입니다.


## 리뷰 요구사항 (선택)

> 회원가입시 passwordEncoder를 사용했는데, security가 import 돼있지 않으시다면 에러가 발생할 가능성이 있습니다.
security import는 주의해서 해주세요 테스트시에 필터가 걸립니다!
