### PR TITLE
[Feat] StoreRequirement를 활용한 Store의 등록/수정/삭제 기능 재수정

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.team.b6.catchtable.domain.member.dto.response.AdminResponse
+import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
 import org.team.b6.catchtable.domain.store.model.StoreRequirementCategory
 import org.team.b6.catchtable.domain.store.repository.StoreRequirementRepository
 import org.team.b6.catchtable.domain.store.service.StoreService
@@ -21,9 +22,20 @@ class AdminService(
         getStoreRequirement(storeRequirementId)
             .let {
                 when (it.requirement) {
-                    StoreRequirementCategory.CREATE -> TODO()
-                    StoreRequirementCategory.UPDATE -> TODO()
-                    StoreRequirementCategory.DELETE -> TODO()
+                    StoreRequirementCategory.CREATE -> storeService.registerStore(it.store!!)
+
+                    StoreRequirementCategory.UPDATE -> storeService.updateStore(
+                        storeId = it.requireTo!!,
+                        request = StoreRequest(
+                            it.store!!.name,
+                            it.store.category.name,
+                            it.store.description,
+                            it.store.phone,
+                            it.store.address
+                        )
+                    )
+
+                    StoreRequirementCategory.DELETE -> storeService.deleteStore(it.requireTo!!)
                 }
             }.run { deleteStoreRequirement(storeRequirementId) }
     }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
@@ -37,10 +37,9 @@ class StoreController(
     }
 
     @PostMapping
-    fun createStore(@RequestBody createStoreRequest: StoreRequest): ResponseEntity<StoreResponse> {
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(storeService.createStore(createStoreRequest))
+    fun registerStore(@RequestBody request: StoreRequest): ResponseEntity<Unit> {
+        storeRequirementService.applyForRegister(request)
+        return ResponseEntity.ok().build()
     }
 
     @PutMapping("/{storeId}")
@@ -48,7 +47,7 @@ class StoreController(
         @PathVariable storeId: Long,
         @RequestBody updateStoreRequest: StoreRequest
     ): ResponseEntity<Unit> {
-        storeService.updateStore(storeId, updateStoreRequest)
+        storeRequirementService.applyForUpdate(storeId, updateStoreRequest)
         return ResponseEntity.ok().build()
     }
 
@@ -56,7 +55,7 @@ class StoreController(
     fun deleteStore(
         @PathVariable storeId: Long
     ): ResponseEntity<Unit> {
-        storeService.deleteStore(storeId)
+        storeRequirementService.applyForDelete(storeId)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
@@ -21,9 +21,11 @@ data class StoreRequest(
         address = address
     )
 
-    fun to(requirement: StoreRequirementCategory, store: Store?) = StoreRequirement(
-        requirement = requirement,
-        store = store,
-        createdAt = LocalDateTime.now()
-    )
+    fun to(requirement: StoreRequirementCategory, store: Store? = null, requireTo: Long? = null) =
+        StoreRequirement(
+            requirement = requirement,
+            store = store,
+            requireTo = requireTo,
+            createdAt = LocalDateTime.now()
+        )
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/model/StoreRequirement.kt
@@ -15,7 +15,10 @@ class StoreRequirement(
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(name = "store_id")
-    val store: Store?,
+    val store: Store? = null,
+
+    @Column(name = "require_to")
+    val requireTo: Long? = null, // UPDATE, DELETE 시 대상이 되는 Store의 Id (FK가 아님을 구분하기 위해 requireTo라는 컬럼명 사용)
 
     @Column(name = "created_at", columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
     val createdAt: LocalDateTime

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreRequirementService.kt
@@ -1,49 +1,42 @@
 package org.team.b6.catchtable.domain.store.service
 
-import jakarta.transaction.Transactional
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
 import org.team.b6.catchtable.domain.store.model.StoreRequirement
 import org.team.b6.catchtable.domain.store.model.StoreRequirementCategory
 import org.team.b6.catchtable.domain.store.repository.StoreRequirementRepository
-import org.team.b6.catchtable.domain.store.repository.StoreRepository
 import java.time.LocalDateTime
 
 @Service
 @Transactional
 class StoreRequirementService(
-    private val storeRepository: StoreRepository,
     private val storeRequirementRepository: StoreRequirementRepository
 ) {
-    fun applyForRegister(storeRequest: StoreRequest) {
+    fun applyForRegister(storeRequest: StoreRequest) =
         storeRequirementRepository.save(
             storeRequest.to(
                 requirement = StoreRequirementCategory.CREATE,
                 store = storeRequest.to()
             )
         )
-    }
 
-    fun applyForUpdate(storeId: Long, storeRequest: StoreRequest) {
+    fun applyForUpdate(storeId: Long, storeRequest: StoreRequest) =
         storeRequirementRepository.save(
             storeRequest.to(
                 requirement = StoreRequirementCategory.UPDATE,
-                store = getStore(storeId)
+                store = storeRequest.to(),
+                requireTo = storeId
             )
         )
-    }
 
     fun applyForDelete(storeId: Long) {
         storeRequirementRepository.save(
             StoreRequirement(
                 requirement = StoreRequirementCategory.DELETE,
-                store = getStore(storeId),
+                requireTo = storeId,
                 createdAt = LocalDateTime.now()
             )
         )
     }
-
-    private fun getStore(storeId: Long) =
-        storeRepository.findByIdOrNull(storeId) ?: throw Exception("")
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
 import org.team.b6.catchtable.domain.store.dto.response.StoreResponse
+import org.team.b6.catchtable.domain.store.model.Store
 import org.team.b6.catchtable.domain.store.model.StoreCategory
 import org.team.b6.catchtable.domain.store.repository.StoreRepository
 import org.team.b6.catchtable.global.exception.InvalidStoreSearchingValuesException
@@ -33,12 +34,10 @@ class StoreService(
         StoreResponse.from(getStore(storeId))
 
     // 식당 등록
-    fun createStore(request: StoreRequest) =
-        StoreResponse.from(storeRepository.save(request.to()))
+    fun registerStore(requiredStore: Store) = storeRepository.save(requiredStore)
 
     // 식당 수정
-    fun updateStore(storeId: Long, request: StoreRequest) =
-        getStore(storeId).update(request)
+    fun updateStore(storeId: Long, request: StoreRequest) = getStore(storeId).update(request)
 
     // 식당 제거
     fun deleteStore(storeId: Long) = storeRepository.deleteById(storeId)


### PR DESCRIPTION
## 연관된 이슈

#19 

## 작업 내용

- [ ] StoreRequirement에 requireTo 속성 추가
    - UPDATE, DELETE 시 수정/삭제의 대상이 되는 Store의 Id도 같이 저장
    - FK가 아님을 구분하기 위해 컬럼명을 store_id가 아닌 requireTo로 설정
- [ ] StoreRequirementService의 applyForRegister~applyForDelete 메서드 구현
- [ ] AdminService의 acceptStoreRequirement 메서드 구현
    - CREATE 시에는 추가하고자 하는 store 객체를 StoreService에 넘겨줌
    - UPDATE 시에는 변경하고자 하는 대상 store의 Id와, StoreRequest를 새로 생성하여 StoreService에 넘겨줌
    - DELETE 시에는 삭제하고자 하는 대상 store의 Id를 StoreService에 넘겨줌