### PR TITLE
[Feat] Store의 등록/수정/삭제 요청 후, 이메일을 통한 승인 여부 전송

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,13 +27,15 @@ dependencies {
     // DB
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("com.h2database:h2")
+    // MAIL
+    implementation("org.springframework.boot:spring-boot-starter-mail:3.2.2")
     // REFLECTION
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     // SECURITY
-//	implementation("org.springframework.boot:spring-boot-starter-security")
-//	implementation("io.jsonwebtoken:jjwt-api:0.12.3")
-//	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
-//	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
     // SWAGGER
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
     // TEST

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -2,17 +2,19 @@ package org.team.b6.catchtable.domain.member.service
 
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Service
 import org.team.b6.catchtable.domain.member.dto.response.AdminResponse
 import org.team.b6.catchtable.domain.store.model.StoreRequirementCategory
 import org.team.b6.catchtable.domain.store.repository.StoreRequirementRepository
-import org.team.b6.catchtable.domain.store.service.StoreService
+import org.team.b6.catchtable.global.variable.Strings
 
 @Service
 @Transactional
 class AdminService(
-    private val storeService: StoreService,
-    private val storeRequirementRepository: StoreRequirementRepository
+    private val storeRequirementRepository: StoreRequirementRepository,
+    private val javaMailSender: JavaMailSender
 ) {
     fun findAllStoreRequirements() =
         storeRequirementRepository.findAll().filter { !it.isAccepted }.map { AdminResponse.from(it) }
@@ -25,7 +27,10 @@ class AdminService(
                     StoreRequirementCategory.UPDATE -> TODO()
                     StoreRequirementCategory.DELETE -> TODO()
                 }
-            }.run { deleteStoreRequirement(storeRequirementId) }
+            }.run {
+                // TODO : 메일 전송 로직 추가
+                deleteStoreRequirement(storeRequirementId)
+            }
     }
 
     private fun deleteStoreRequirement(storeChangeId: Long) =
@@ -33,4 +38,21 @@ class AdminService(
 
     private fun getStoreRequirement(storeChangeId: Long) =
         storeRequirementRepository.findByIdOrNull(storeChangeId) ?: throw Exception("") // TODO : 추후 구현
+
+    private fun sendMail(email: String, requirement: StoreRequirementCategory, isAccepted: Boolean) {
+        SimpleMailMessage().let {
+            it.replyTo = email
+            it.subject = Strings.MAIL_SUBJECT
+
+            if (isAccepted) {
+                when (requirement) {
+                    StoreRequirementCategory.CREATE -> it.text = Strings.MAIL_CONTENT_STORE_CREATE_ACCEPTED
+                    StoreRequirementCategory.UPDATE -> it.text = Strings.MAIL_CONTENT_STORE_UPDATE_ACCEPTED
+                    StoreRequirementCategory.DELETE -> it.text = Strings.MAIL_CONTENT_STORE_DELETE_ACCEPTED
+                }
+            }
+
+            javaMailSender.send(it)
+        }
+    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/global/variable/Strings.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/variable/Strings.kt
@@ -1,0 +1,8 @@
+package org.team.b6.catchtable.global.variable
+
+object Strings {
+    const val MAIL_SUBJECT = "[캐치테이블] 사장님의 요청이 정상적으로 승인되었습니다."
+    const val MAIL_CONTENT_STORE_CREATE_ACCEPTED = "식당 등록이 완료되었습니다. 캐치 테이블의 소중한 일원이 되신 것을 환영합니다!"
+    const val MAIL_CONTENT_STORE_UPDATE_ACCEPTED = "식당 정보 수정이 완료되었습니다. 오늘도 좋은 하루 되세요!"
+    const val MAIL_CONTENT_STORE_DELETE_ACCEPTED = "식당 삭제가 완료되었습니다. 다음에 또 볼 수 있는 기회가 있었으면 좋겠습니다ㅠㅠ"
+}


### PR DESCRIPTION
## 연관된 이슈

#32 

## 작업 내용

- [ ] 이메일을 위한 라이브러리 추가 (spring-boot-starter-mail)
- [ ] AdminService에 이메일을 전송하는 내부 메서드 sendMail 생성
    - JavaMailSender과 SimpleMailMessage 객체를 활용하여 메일 전송
    - 등록/수정/삭제 총 3가지 경우로 나누어 코드 작성
- [ ] Strings Object에 이메일 제목과 내용을 설정

## 리뷰 요구사항 (선택)

현재 dev 브랜치에서 테스트를 완벽하게 수행할 수 없는 상황이라 추후에 코드가 변경될 수 있습니다.
