### PR TITLE
[feat] 인증,인가 처리시 401,403 Exception처리 필터추가

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/global/dto/ErrorMessageResponse.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/dto/ErrorMessageResponse.kt
@@ -1,0 +1,5 @@
+package org.team.b6.catchtable.global.dto
+
+data class ErrorMessageResponse(
+    val message: String?
+)

--- a/src/main/kotlin/org/team/b6/catchtable/global/security/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/security/CustomAccessDeniedHandler.kt
@@ -1,0 +1,29 @@
+package org.team.b6.catchtable.global.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+import org.team.b6.catchtable.global.dto.ErrorMessageResponse
+
+@Component
+class CustomAccessDeniedHandler : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        response.status = HttpServletResponse.SC_FORBIDDEN
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+
+        val objectMapper = ObjectMapper()
+        val jsonString = objectMapper.writeValueAsString(
+            ErrorMessageResponse("No permission to run API")
+        )
+        response.writer.write(jsonString)
+    }
+}

--- a/src/main/kotlin/org/team/b6/catchtable/global/security/CustomAuthenticationEntrypoint.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/security/CustomAuthenticationEntrypoint.kt
@@ -1,0 +1,28 @@
+package org.team.b6.catchtable.global.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import org.team.b6.catchtable.global.dto.ErrorMessageResponse
+
+@Component
+class CustomAuthenticationEntrypoint : AuthenticationEntryPoint {
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+
+        val objectMapper = ObjectMapper()
+        val jsonString = objectMapper.writeValueAsString(ErrorMessageResponse("No permission to run API"))
+        response.writer.write(jsonString)
+    }
+}

--- a/src/main/kotlin/org/team/b6/catchtable/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/security/SecurityConfig.kt
@@ -5,7 +5,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.team.b6.catchtable.global.security.jwt.JwtAuthenticationFilter
 
@@ -13,7 +15,9 @@ import org.team.b6.catchtable.global.security.jwt.JwtAuthenticationFilter
 @EnableWebSecurity
 @EnableMethodSecurity
 class SecurityConfig(
-    private val jwtAuthenticationFilter: JwtAuthenticationFilter
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val authenticationEntrypoint: AuthenticationEntryPoint,
+    private val accessDeniedHandler: AccessDeniedHandler
 ) {
 
     @Bean
@@ -36,6 +40,10 @@ class SecurityConfig(
                     .anyRequest().authenticated()
             }
             .addFilterBefore(jwtAuthenticationFilter,UsernamePasswordAuthenticationFilter::class.java)
+            .exceptionHandling{
+                it.authenticationEntryPoint(authenticationEntrypoint)
+                it.accessDeniedHandler(accessDeniedHandler)
+            }
             .build()
     }
 }


### PR DESCRIPTION
## 연관된 이슈

#45 
## 작업 내용

- [ ] Security에서 인증, 인가시 올바른 Status를 던져주기 위한 authenticationEntrypoint, accessDeniedHandler를 작성하였습니다. 
- [ ] accessDeniedHandler,authenticationEntrypoint에서 사용하기 위해 단순히 에러메세지만 전달해주는 ErrorMessageResponse DTO를 추가하였습니다.
- [ ] SecurityConfig는 개개인의 환경에 따라 다르게 작동할 수 있으니 유의해주시길 바랍니다

## 리뷰 요구사항 (선택)

SecurityConfig는 환경에 따라 다르게 작동할 수 있으니 정말정말 유의하셔야합니다!!!! 