### PR TITLE
[BugFix] InvalidCredentialException 추가, 닉네임,비밀번호 유효성검사 수정

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/SignupMemberRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/SignupMemberRequest.kt
@@ -1,22 +1,18 @@
 package org.team.b6.catchtable.domain.member.dto.request
 
-
 import jakarta.validation.constraints.Pattern
 import org.team.b6.catchtable.domain.member.model.Member
 import org.team.b6.catchtable.domain.member.model.MemberRole
 
 data class SignupMemberRequest(
     val role: String?,
-    @Pattern(regexp = "^(?=.*[a-z])(?=.*[0-9]).{4,10}\$",
-        message = "닉네임은 영어 소문자와 숫자로 이루어져 있습니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[0-9]).{4,10}\$", message = "닉네임은 영어 소문자와 숫자로 이루어져 있습니다.")
     val nickname: String,
     val name: String,
     val email: String,
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=]).{8,15}$",
-        message = "닉네임은 영어 소문자와 대문자, 숫자, 특수문자(@#$%^&+=)로 이루어져 있어야 합니다.")
+        message = "비밀번호는 영어 소문자와 대문자, 숫자, 특수문자(@#$%^&+=)로 이루어져 있어야 합니다.")
     val password: String,
 ) {
     //fun to() = Member(MemberRole.valueOf(role), nickname, name, email, password)
 }
-
-

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
@@ -52,7 +52,7 @@ class MemberService(
     }
 
     fun login(request: LoginRequest): LoginResponse {
-        val member = memberRepository.findByEmail(request.email) ?: throw ModelNotFoundException("멤버")
+        val member = memberRepository.findByEmail(request.email) ?: throw ModelNotFoundException("member")
         if (member.role.name != request.role) throw InvalidCredentialException("role")
         if (!passwordEncoder.matches(request.password, member.password)) throw InvalidCredentialException("password")
 
@@ -73,19 +73,28 @@ class MemberService(
 
     fun getMember(id: Long): MemberResponse {
         val foundMember = memberRepository.findByIdOrNull(id)
-            ?: throw Exception("Temp")
+            ?: throw ModelNotFoundException("member")
         return MemberResponse.from(foundMember)
     }
 
     fun isValidNickname(nickname: String?): Boolean {
         val trimmedNickname = nickname?.trim().toString()
         val exp = Regex("^(?=.*[a-z])(?=.*[0-9]).{4,10}\$")
-        return !trimmedNickname.isNullOrEmpty() && exp.matches(trimmedNickname)
+        if (!trimmedNickname.isNullOrEmpty() && exp.matches(trimmedNickname)) {
+            return true
+        } else {
+            throw IllegalArgumentException("Invalid nickname")
+        }
     }
+
     fun isValidPassword(password: String?): Boolean {
         val trimmedPassword = password?.trim().toString()
-        val exp = Regex("^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#\$%^&+=]).{8,15}\$")
-        return !trimmedPassword.isNullOrEmpty() && exp.matches(trimmedPassword)
+        val exp = Regex("^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=]).{8,15}$")
+        if (!trimmedPassword.isNullOrEmpty() && exp.matches(trimmedPassword)) {
+            return true
+        } else {
+            throw IllegalArgumentException("Invalid password")
+        }
     }
 }
 

--- a/src/main/kotlin/org/team/b6/catchtable/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/exception/GlobalExceptionHandler.kt
@@ -60,4 +60,14 @@ class GlobalExceptionHandler(
                 path = httpServletRequest.requestURI
             )
         )
+
+    @ExceptionHandler(InvalidCredentialException::class)
+    fun handleInvalidCredentialException(e: InvalidCredentialException) =
+        ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+            ErrorResponse(
+                httpStatus = "401 Unauthorized",
+                message = e.message.toString(),
+                path = httpServletRequest.requestURI
+            )
+        )
 }


### PR DESCRIPTION
## 연관된 이슈

#53 
## 작업 내용

- [ ] 회원가입시 저희 정책에 맞는 닉네임, 비밀번호의 유효성을 검사해 올바르지 않으면 Exception을 내보내는 로직을 Service에 추가하였습니다.
- [ ] GlobalExceptionHandler에 InvalidCredentialException도 추가하였습니다.
- [ ] 기존 foundMember에 빠져있던 ModelNotFoundException 또한 추가하였습니다.

## 리뷰 요구사항 (선택)

