### PR TITLE
[BugFix] Store 정보 수정 시 중복 로직이 오적용되는 버그 수정

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/repository/StoreRepository.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/repository/StoreRepository.kt
@@ -13,6 +13,10 @@ interface StoreRepository : JpaRepository<Store, Long> {
 
     fun findAllByCategory(category: StoreCategory, sort: Sort): List<Store>
 
+    fun findByName(name: String): Store?
+
+    fun findByAddress(address: String): Store?
+
     fun existsByAddress(address: String): Boolean
 
     fun existsByName(name: String): Boolean

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -44,7 +44,7 @@ class StoreService(
 
     // 식당 수정
     fun updateStore(storeId: Long, request: StoreRequest) =
-        validateNameAndAddress(request.name, request.address)
+        validateNameAndAddress(request.name, request.address, storeId)
             .run { getStore(storeId).update(request) }
 
     // 식당 제거
@@ -69,8 +69,17 @@ class StoreService(
             }
 
     private fun validateNameAndAddress(name: String, address: String) {
-        if (storeRepository.existsByName(name)) throw DuplicatedValueException("상호명")
-        else if (storeRepository.existsByAddress(address)) throw DuplicatedValueException("식당 주소")
+        if (storeRepository.existsByName(name))
+            throw DuplicatedValueException("상호명")
+        else if (storeRepository.existsByAddress(address))
+            throw DuplicatedValueException("식당 주소")
+    }
+
+    private fun validateNameAndAddress(name: String, address: String, storeId: Long) {
+        if (storeRepository.existsByName(name) && (storeRepository.findByName(name)!!.id != storeId))
+            throw DuplicatedValueException("상호명")
+        else if (storeRepository.existsByAddress(address) && (storeRepository.findByAddress(address)!!.id != storeId))
+            throw DuplicatedValueException("식당 주소")
     }
 
     private fun availableToReservation(status: StoreStatus) = (status == StoreStatus.OK)


### PR DESCRIPTION
## 연관된 이슈

#55 

## 작업 내용

- [ ] StoreRepository에 findByName과 findByAddress 메서드 생성
- [ ] 중복 검증 시, 본인의 name과 address는 검증 대상에 들어가지 않게 조건문 수정