### PR TITLE
[Feat] ADMIN 관련 클래스들 리팩토링

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
@@ -13,9 +13,11 @@ class AdminController(
     fun findAllStoreRequirements() =
         ResponseEntity.ok().body(adminService.findAllStoreRequirements())
 
-    @PostMapping("/stores/{storeId}")
+    @PostMapping("/stores/{storeId}/success")
     fun acceptStoreRequirement(@PathVariable storeId: Long) =
-        ResponseEntity.ok().body(adminService.accept(storeId))
+        ResponseEntity.ok().body(adminService.handleRequirement(storeId, true))
 
-    // TODO: declineStoreRequest 메서드 추후 생성
+    @PostMapping("/stores/{storeId}/fail")
+    fun refuseStoreRequirement(@PathVariable storeId: Long) =
+        ResponseEntity.ok().body(adminService.handleRequirement(storeId, false))
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -1,63 +1,67 @@
 package org.team.b6.catchtable.domain.member.service
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.team.b6.catchtable.domain.store.model.StoreStatus
-import org.team.b6.catchtable.domain.store.repository.StoreRepository
-import org.team.b6.catchtable.global.exception.ModelNotFoundException
+import org.team.b6.catchtable.global.service.GlobalService
 import org.team.b6.catchtable.global.variable.Variables
 
 @Service
 @Transactional
 class AdminService(
-    private val storeRepository: StoreRepository,
+    private val globalService: GlobalService,
     private val javaMailSender: JavaMailSender
 ) {
+    @PreAuthorize("hasRole('ADMIN')")
     fun findAllStoreRequirements() =
-        storeRepository.findAll()
-            .filter { unavailableToReservation(it.status) }
+        globalService.getAllStores().filter { unavailableToReservation(it.status) }
 
-    // TODO : 추후 코드 리팩토링 필요
-    fun accept(storeId: Long) =
-        getStore(storeId).let {
+    @PreAuthorize("hasRole('ADMIN')")
+    fun handleRequirement(storeId: Long, isAccepted: Boolean) =
+        globalService.getStore(storeId).let {
             when (it.status) {
                 StoreStatus.WAITING_FOR_CREATE -> {
-                    sendMail(
-                        email = "", // TODO : 추후 대상 이메일 설정
-                        text = Variables.MAIL_CONTENT_STORE_CREATE_ACCEPTED,
-                        isAccepted = true
+                    if (isAccepted) {
+                        sendMail(
+                            email = globalService.getMember(it.belongTo).email,
+                            text = Variables.MAIL_CONTENT_STORE_CREATE_ACCEPTED
+                        )
+                        it.updateStatus(StoreStatus.OK)
+                    } else sendMail(
+                        email = globalService.getMember(it.belongTo).email,
+                        text = Variables.MAIL_CONTENT_STORE_CREATE_REFUSED
                     )
-                    it.updateStatus(StoreStatus.OK)
                 }
 
                 StoreStatus.WAITING_FOR_DELETE -> {
-                    sendMail(
-                        email = "",
-                        text = Variables.MAIL_CONTENT_STORE_DELETE_ACCEPTED,
-                        isAccepted = true
+                    if (isAccepted) {
+                        sendMail(
+                            email = globalService.getMember(it.belongTo).email,
+                            text = Variables.MAIL_CONTENT_STORE_DELETE_ACCEPTED
+                        )
+                        it.updateForDelete()
+                    } else sendMail(
+                        email = globalService.getMember(it.belongTo).email,
+                        text = Variables.MAIL_CONTENT_STORE_DELETE_REFUSED
                     )
-                    it.updateForDelete()
                 }
 
                 else -> {}
             }
         }
 
-    private fun getStore(storeId: Long) =
-        (storeRepository.findByIdOrNull(storeId) ?: throw ModelNotFoundException("식당"))
-
-    private fun sendMail(email: String, text: String, isAccepted: Boolean) {
-        val mimeMessage = javaMailSender.createMimeMessage()
-        val helper = MimeMessageHelper(mimeMessage, false)
-        helper.setTo(email)
-        helper.setSubject(Variables.MAIL_SUBJECT)
-        helper.setText(text)
-        javaMailSender.send(mimeMessage)
-    }
-
+    private fun sendMail(email: String, text: String) =
+        javaMailSender.createMimeMessage().let {
+            MimeMessageHelper(it, false).let { helper ->
+                helper.setTo(email)
+                helper.setSubject(Variables.MAIL_SUBJECT)
+                helper.setText(text)
+            }
+            javaMailSender.send(it)
+        }
 
     private fun unavailableToReservation(status: StoreStatus) =
         (status == StoreStatus.WAITING_FOR_CREATE) || (status == StoreStatus.WAITING_FOR_DELETE) || (status == StoreStatus.DELETED)

--- a/src/main/kotlin/org/team/b6/catchtable/global/service/GlobalService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/service/GlobalService.kt
@@ -1,0 +1,30 @@
+package org.team.b6.catchtable.global.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.team.b6.catchtable.domain.member.repository.MemberRepository
+import org.team.b6.catchtable.domain.review.repository.ReviewRepository
+import org.team.b6.catchtable.domain.store.repository.StoreRepository
+import org.team.b6.catchtable.global.exception.ModelNotFoundException
+
+@Service
+class GlobalService(
+    private val memberRepository: MemberRepository,
+    private val storeRepository: StoreRepository,
+    private val reviewRepository: ReviewRepository
+) {
+    fun getAllMembers() = memberRepository.findAll()
+
+    fun getMember(memberId: Long) =
+        memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("멤버")
+
+    fun getAllStores() = storeRepository.findAll()
+
+    fun getStore(storeId: Long) =
+        storeRepository.findByIdOrNull(storeId) ?: throw ModelNotFoundException("식당")
+
+    fun getAllReviews() = memberRepository.findAll()
+
+    fun getReview(reviewId: Long) =
+        reviewRepository.findByIdOrNull(reviewId) ?: throw ModelNotFoundException("리뷰")
+}

--- a/src/main/kotlin/org/team/b6/catchtable/global/variable/Variables.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/variable/Variables.kt
@@ -5,6 +5,7 @@ object Variables {
 
     const val MAIL_SUBJECT = "[캐치테이블] 사장님의 요청이 정상적으로 승인되었습니다."
     const val MAIL_CONTENT_STORE_CREATE_ACCEPTED = "식당 등록이 완료되었습니다. 캐치 테이블의 소중한 일원이 되신 것을 환영합니다!"
-    const val MAIL_CONTENT_STORE_UPDATE_ACCEPTED = "식당 정보 수정이 완료되었습니다. 오늘도 좋은 하루 되세요!"
     const val MAIL_CONTENT_STORE_DELETE_ACCEPTED = "식당 삭제가 완료되었습니다. 다음에 또 볼 수 있는 기회가 있었으면 좋겠습니다ㅠㅠ"
+    const val MAIL_CONTENT_STORE_CREATE_REFUSED = "식당 등록이 거절되었습니다. 자세한 사유는 고객센터(1234-5678)로 연락주세요."
+    const val MAIL_CONTENT_STORE_DELETE_REFUSED = "식당이 정상적으로 삭제되지 않았습니다. 자세한 사유는 고객센터(1234-5678)을 통해 확인해주세요."
 }


### PR DESCRIPTION
## 연관된 이슈

#64 

## 작업 내용

- [ ] AdminController에 refuseStoreRequirement 메서드 추가
- [ ] AdminService에 handleStoreRequirement 메서드 추가 (승인과 거절 시 로직을 하나의 클래스에서 구현)
- [ ] AdminService의 모든 메서드에 권한 부여 (ADMIN만 가능하게끔)
- [ ] Variables에 요청 거절 시 전송하는 메일의 내용을 추가
- [ ] 불필요한 코드 남발을 방지하기 위해, 모든 엔티티에 대한 단일 조회, 전체 조회 로직을 하나의 GlobalService에서 수행
    - 필요한 클래스에서 GlobalService 객체를 주입받아 단일 조회/전체 조회를 사용
