### PR TITLE
[Test] Swagger 테스트를 위한 임시 ADMIN 회원가입 기능 구현

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
@@ -2,6 +2,7 @@ package org.team.b6.catchtable.domain.member.controller
 
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.team.b6.catchtable.domain.member.dto.request.SignupMemberRequest
 import org.team.b6.catchtable.domain.member.service.AdminService
 
 @RestController
@@ -20,4 +21,10 @@ class AdminController(
     @PostMapping("/stores/{storeId}/fail")
     fun refuseStoreRequirement(@PathVariable storeId: Long) =
         ResponseEntity.ok().body(adminService.handleRequirement(storeId, false))
+
+    // TODO: 추후 삭제 (테스트용)
+    @PostMapping
+    fun registerAdmin(@RequestBody request: SignupMemberRequest) {
+        ResponseEntity.ok().body(adminService.registerAdmin(request))
+    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/SignupMemberRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/SignupMemberRequest.kt
@@ -1,6 +1,7 @@
 package org.team.b6.catchtable.domain.member.dto.request
 
 import jakarta.validation.constraints.Pattern
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.team.b6.catchtable.domain.member.model.Member
 import org.team.b6.catchtable.domain.member.model.MemberRole
 
@@ -14,5 +15,6 @@ data class SignupMemberRequest(
         message = "비밀번호는 영어 소문자와 대문자, 숫자, 특수문자(@#$%^&+=)로 이루어져 있어야 합니다.")
     val password: String,
 ) {
-    //fun to() = Member(MemberRole.valueOf(role), nickname, name, email, password)
+    fun to(passwordEncoder: PasswordEncoder) =
+        Member(MemberRole.valueOf(role!!), nickname, name, email, passwordEncoder.encode(password))
 }

--- a/src/main/kotlin/org/team/b6/catchtable/global/variable/Variables.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/variable/Variables.kt
@@ -3,7 +3,8 @@ package org.team.b6.catchtable.global.variable
 object Variables {
     val CRITERIA_LIST = mutableListOf("name")
 
-    const val MAIL_SUBJECT = "[캐치테이블] 사장님의 요청이 정상적으로 승인되었습니다."
+    const val MAIL_SUBJECT_ACCEPTED = "[캐치테이블] 사장님의 요청이 정상적으로 승인되었습니다."
+    const val MAIL_SUBJECT_REFUSED = "[캐치테이블] 사장님의 요청이 거절되었습니다."
     const val MAIL_CONTENT_STORE_CREATE_ACCEPTED = "식당 등록이 완료되었습니다. 캐치 테이블의 소중한 일원이 되신 것을 환영합니다!"
     const val MAIL_CONTENT_STORE_DELETE_ACCEPTED = "식당 삭제가 완료되었습니다. 다음에 또 볼 수 있는 기회가 있었으면 좋겠습니다ㅠㅠ"
     const val MAIL_CONTENT_STORE_CREATE_REFUSED = "식당 등록이 거절되었습니다. 자세한 사유는 고객센터(1234-5678)로 연락주세요."


### PR DESCRIPTION
## 연관된 이슈

#71 

## 작업 내용

- [ ] AdminController, AdminService에 (임시로) 회원가입 기능 구현 --> 추후 삭제 예정
- [ ] SignupMemberRequest의 to메서드 활성화
- [ ] AdminService 내에서 OWNER의 요청 거절 시, 메일 제목이 제대로 작동하지 않는 버그 일부 수정

## 리뷰 요구사항 (선택)

임시로 만든 기능이라 월요일 오전에 삭제 예정입니다!
