### PR TITLE
[Feat] 주문 많은 수로 Store를 정렬하는 로직 구현

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
@@ -1,6 +1,5 @@
 package org.team.b6.catchtable.domain.store.controller
 
-import org.springframework.data.domain.Sort
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -21,11 +20,10 @@ class StoreController(
     @GetMapping("/{category}/sorted")
     fun findAllStoresByCategoryWithSortCriteria(
         @PathVariable category: String,
-        @RequestParam direction: Sort.Direction,
         @RequestParam criteria: String
     ) =
         ResponseEntity.ok().body(
-            storeService.findAllStoresByCategoryWithSortCriteria(category, direction, criteria)
+            storeService.findAllStoresByCategoryWithSortCriteria(category, criteria)
         )
 
     @GetMapping("/store/{storeId}")

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
@@ -1,6 +1,5 @@
 package org.team.b6.catchtable.domain.store.dto.request
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import org.team.b6.catchtable.domain.store.model.Store
 import org.team.b6.catchtable.domain.store.model.StoreCategory
 import java.time.LocalTime
@@ -11,10 +10,8 @@ data class StoreRequest(
     val description: String,
     val phone: String,
     val address: String,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-    val openTime: LocalTime,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-    val closeTime: LocalTime
+    val openTime: Int,
+    val closeTime: Int
 ) {
     fun to(ownerId: Long) = Store(
         belongTo = ownerId,
@@ -23,7 +20,7 @@ data class StoreRequest(
         description = description,
         phone = phone,
         address = address,
-        openTime = openTime,
-        closeTime = closeTime
+        openTime = LocalTime.of(openTime, 0),
+        closeTime = LocalTime.of(closeTime, 0)
     )
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/model/Store.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/model/Store.kt
@@ -1,6 +1,5 @@
 package org.team.b6.catchtable.domain.store.model
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import jakarta.persistence.*
 import org.team.b6.catchtable.domain.store.dto.request.StoreRequest
 import org.team.b6.catchtable.global.entity.BaseEntity
@@ -28,12 +27,10 @@ class Store(
     @Column(name = "address", nullable = false)
     var address: String,
 
-    @Column(name = "open_time", columnDefinition = "TIMESTAMP(6)", nullable = false)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    @Column(name = "open_time", columnDefinition = "TIME", nullable = false)
     var openTime: LocalTime,
 
-    @Column(name = "close_time", columnDefinition = "TIMESTAMP(6)", nullable = false)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    @Column(name = "close_time", columnDefinition = "TIME", nullable = false)
     var closeTime: LocalTime
 ) : BaseEntity() {
     @Id

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -1,6 +1,5 @@
 package org.team.b6.catchtable.domain.store.service
 
-import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,7 +14,6 @@ import org.team.b6.catchtable.global.exception.DuplicatedValueException
 import org.team.b6.catchtable.global.exception.InvalidStoreSearchingValuesException
 import org.team.b6.catchtable.global.exception.ModelNotFoundException
 import org.team.b6.catchtable.global.security.MemberPrincipal
-import org.team.b6.catchtable.global.variable.Variables
 
 @Service
 @Transactional
@@ -33,22 +31,10 @@ class StoreService(
     // 카테고리와 정렬 조건을 사용하여 식당 전체 조회
     fun findAllStoresByCategoryWithSortCriteria(category: String, criteria: String) =
         when (criteria) {
-//            "name" -> sortByName(category, direction)
+            // TODO: 추후 정렬 조건 추가
             "reservation" -> sortByNumberOfReservations(category)
             else -> throw InvalidStoreSearchingValuesException("criteria")
         }
-
-//    // 카테고리와 정렬 조건을 사용하여 식당 전체 조회
-//    private fun sortByName(category: String, direction: Sort.Direction) =
-//        storeRepository.findAllByCategory(getCategory(category), Sort.by(direction, "name"))
-//            .filter { availableToReservation(it.status) }
-//            .map { StoreResponse.from(it, getMember(it.belongTo)) }
-
-    private fun sortByNumberOfReservations(category: String) =
-        storeRepository.findAllByCategory(getCategory(category))
-            .filter { availableToReservation(it.status) }
-            .sortedByDescending { reservationRepository.findAll().count { reservation -> reservation.store.id == it.id } }
-            .map { StoreResponse.from(it, getMember(it.belongTo)) }
 
     // 식당 단일 조회
     fun findStore(storeId: Long) =
@@ -101,4 +87,10 @@ class StoreService(
     }
 
     private fun availableToReservation(status: StoreStatus) = (status == StoreStatus.OK)
+
+    private fun sortByNumberOfReservations(category: String) =
+        storeRepository.findAllByCategory(getCategory(category))
+            .filter { availableToReservation(it.status) }
+            .sortedByDescending { reservationRepository.findAll().count { reservation -> reservation.store.id == it.id } }
+            .map { StoreResponse.from(it, getMember(it.belongTo)) }
 }


### PR DESCRIPTION
## 연관된 이슈

#73 

## 작업 내용

- [ ] '주문 많은 수' 조건으로 Store을 정렬하는 로직 구현
- [ ] 기존에 '이름' 조건으로 Store를 정렬하던 로직 제거 (활용성 미비)
- [ ] StoreController에서 오름차순/내림차순 여부를 받지 않는 것으로 설정
- [ ] Store 엔티티의 openTime과 closeTime의 자료형을 LocalTime으로 수정 (DB에서는 TIME 자료형으로 수정)
- [ ] StoreRequest에서는 정수값을 받고, 이를 Store 엔티티로 변환하는 과정에서 LocalTime 자료형으로 전환