### PR TITLE
[Feat] Store 등록 과정에서 Validation 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     // VALIDATION
-    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
+    implementation("org.springframework.boot:spring-boot-starter-validation:3.2.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/controller/StoreController.kt
@@ -1,5 +1,6 @@
 package org.team.b6.catchtable.domain.store.controller
 
+import jakarta.validation.Valid
 import org.springframework.data.domain.Sort
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -35,7 +36,7 @@ class StoreController(
     @PostMapping
     fun registerStore(
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
-        @RequestBody request: StoreRequest
+        @RequestBody @Valid request: StoreRequest
     ): ResponseEntity<Unit> =
         ResponseEntity.created(
             URI.create("/stores/store/${storeService.registerStore(memberPrincipal, request)}")

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/dto/request/StoreRequest.kt
@@ -1,20 +1,53 @@
 package org.team.b6.catchtable.domain.store.dto.request
 
-import com.fasterxml.jackson.annotation.JsonFormat
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
+import org.hibernate.validator.constraints.Range
 import org.team.b6.catchtable.domain.store.model.Store
 import org.team.b6.catchtable.domain.store.model.StoreCategory
+import org.team.b6.catchtable.global.aop.ValidCategory
 import java.time.LocalTime
 
 data class StoreRequest(
+    @field:NotBlank
     val name: String,
+
+    @field:NotBlank
+    @field:ValidCategory(
+        message = "유효하지 않은 카테고리입니다.",
+        enumClass = StoreCategory::class
+    )
     val category: String,
+
+    @field:NotBlank
     val description: String,
+
+    @field:NotBlank
+    @field:Pattern(
+        regexp = "^010-?([0-9]{4})-?([0-9]{4})$",
+        message = "휴대폰 형식(010-1234-5678)을 확인해주세요."
+    )
     val phone: String,
+
+    @field:NotBlank
     val address: String,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-    val openTime: LocalTime,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-    val closeTime: LocalTime
+
+    @NotNull
+    @field:Range(
+        min = 5,
+        max = 23,
+        message = "0부터 24까지의 숫자만 입력 가능합니다."
+    )
+    val openTime: Int,
+
+    @NotNull
+    @field:Range(
+        min = 12,
+        max = 23,
+        message = "0부터 24까지의 숫자만 입력 가능합니다."
+    )
+    val closeTime: Int
 ) {
     fun to(ownerId: Long) = Store(
         belongTo = ownerId,
@@ -23,7 +56,7 @@ data class StoreRequest(
         description = description,
         phone = phone,
         address = address,
-        openTime = openTime,
-        closeTime = closeTime
+        openTime = LocalTime.of(openTime, 0),
+        closeTime = LocalTime.of(closeTime, 0)
     )
 }

--- a/src/main/kotlin/org/team/b6/catchtable/global/aop/ValidCategory.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/aop/ValidCategory.kt
@@ -1,0 +1,16 @@
+package org.team.b6.catchtable.global.aop
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Constraint(validatedBy = [Validator::class])
+annotation class ValidCategory(
+    val message: String = "유효하지 않은 카테고리입니다.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+    val enumClass: KClass<out Enum<*>>
+)

--- a/src/main/kotlin/org/team/b6/catchtable/global/aop/Validator.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/aop/Validator.kt
@@ -1,0 +1,15 @@
+package org.team.b6.catchtable.global.aop
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+
+class Validator : ConstraintValidator<ValidCategory, Any> {
+    private lateinit var enumValues: Array<out Enum<*>>
+
+    override fun initialize(annotation: ValidCategory) {
+        enumValues = annotation.enumClass.java.enumConstants
+    }
+
+    override fun isValid(value: Any?, context: ConstraintValidatorContext?) =
+        if (value == null) true else enumValues.any { it.name == value.toString() }
+}

--- a/src/main/kotlin/org/team/b6/catchtable/global/dto/ErrorResponse.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/dto/ErrorResponse.kt
@@ -2,7 +2,6 @@ package org.team.b6.catchtable.global.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.apache.commons.lang3.mutable.Mutable
 import java.time.LocalDateTime
 
 data class ErrorResponse(

--- a/src/main/kotlin/org/team/b6/catchtable/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/exception/GlobalExceptionHandler.kt
@@ -3,6 +3,8 @@ package org.team.b6.catchtable.global.exception
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.team.b6.catchtable.global.dto.ErrorResponse
@@ -68,6 +70,20 @@ class GlobalExceptionHandler(
                 httpStatus = "401 Unauthorized",
                 message = e.message.toString(),
                 path = httpServletRequest.requestURI
+            )
+        )
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException) =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            ErrorResponse(
+                httpStatus = "401 Bad Request",
+                message = e.bindingResult.allErrors.toMutableList().first().defaultMessage!!,
+                path = httpServletRequest.requestURI.toString(),
+                errorContent = e.bindingResult.allErrors.toMutableList().first().let {
+                    it as FieldError
+                    it.field
+                }
             )
         )
 }


### PR DESCRIPTION
## 연관된 이슈

#76 

## 작업 내용

- [ ] StoreRequest에 Validation 구현
- [ ] enum 클래스(Category)에 대한 검증을 위해 ValidCategory 어노테이션과 이를 조작하는 Validator 클래스 생성
- [ ] GlobalExceptionHandler에 MethodArguementNotValidException에 대한 예외 처리 추가
- [ ] build.gradle에 validation 의존성을 jakarta가 아닌 spring-boot-starter에 포함된 것으로 수정
