### PR TITLE
[Feat] : withdraw 회원탈퇴 메소드 추가

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
@@ -31,19 +31,18 @@ class MemberController(
             .body(memberService.login(loginRequest))
     }
 
-    fun emailCheck(){
-        TODO()
-    }
-
-    fun signupCheck() {
-        TODO()
-    }
 
     @PutMapping("/{memberId}")
     fun updateMember(@PathVariable memberId: Long, @RequestBody updateRequest: UpdateMemberRequest): ResponseEntity<MemberResponse>{
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(memberService.updateMember(updateRequest))
+    }
+
+    @PutMapping("/{memberId}/withdraw")
+    fun withdrawMember(@PathVariable memberId: Long): ResponseEntity<Unit>{
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(memberService.withdrawMember(memberId))
     }
 
     @GetMapping
@@ -61,10 +60,5 @@ class MemberController(
             .status(HttpStatus.OK)
             .body(memberService.getMember(memberId))
     }
-
-    //fun logout(){}
-
-    fun memberWithDrawal(){
-        TODO()
-    }
 }
+

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/model/Member.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/model/Member.kt
@@ -8,7 +8,7 @@ import org.team.b6.catchtable.global.entity.BaseEntity
 class Member(
     @Column(name = "role", nullable = false)
     @Enumerated(EnumType.STRING)
-    val role: MemberRole,
+    var role: MemberRole,
 
     @Column(name = "name", nullable = false)
     var name: String,
@@ -20,7 +20,11 @@ class Member(
     val email: String,
 
     @Column(name = "password", nullable = false)
-    var password: String
+    var password: String,
+
+    @Column(name = "is_deleted", nullable = false)
+    var isDeleted: Boolean = false
+
 ) : BaseEntity() {
     @Id
     @Column(name = "member_id")


### PR DESCRIPTION
## 연관된 이슈

#81

## 작업 내용

- [ ] Member Entity에 isDeleted 필드를 추가하였습니다.
- [ ] MeberService에 회원탈퇴를 구현한 withdrawMember 메소드를 구현하였습니다.
 새로 Entity에 추가한 isDeleted 필드를 true로 지정해주며 탈퇴한 회원임을 명시하고, 닉네임을 탈퇴한회원{memberId} 형식으로 변환하며 role을 WITHDRAWN으로 변경해줍니다. 이는 db내의 데이터를 실제로 삭제하는 것이 아닌, 데이터는 유지하되 isDeleted 필드를 이용한 soft-delete 방식입니다.  
저희 정책상 OWNER가 탈퇴할때 store와 review를 같이 hard-delete 방식의 삭제하는 로직도 임시로 주석으로 추가해놨습니다. 다만 이것도 구현한다면, store,review에도 isDeleted 필드를 이용해 soft=delete로 선회하는게 더 긍정적이지 않을까 생각합니다.
- [ ] MemberController에도 withdrawMember 메소드를 추가하고, TODO로 임시로 작성돼있던 메소드를 제거해주었습니다.

## 리뷰 요구사항 (선택)

