### PR TITLE
[refator] : @AuthenticationPrincipal 어노테이션으로 유저인증 변경

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/MemberController.kt
@@ -3,6 +3,7 @@ package org.team.b6.catchtable.domain.member.controller
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import org.team.b6.catchtable.domain.member.dto.request.LoginRequest
 import org.team.b6.catchtable.domain.member.dto.request.SignupMemberRequest
@@ -10,6 +11,7 @@ import org.team.b6.catchtable.domain.member.dto.request.UpdateMemberRequest
 import org.team.b6.catchtable.domain.member.dto.response.LoginResponse
 import org.team.b6.catchtable.domain.member.dto.response.MemberResponse
 import org.team.b6.catchtable.domain.member.service.MemberService
+import org.team.b6.catchtable.global.security.MemberPrincipal
 
 @RestController
 @RequestMapping("/members")
@@ -33,16 +35,16 @@ class MemberController(
 
 
     @PutMapping("/{memberId}")
-    fun updateMember(@PathVariable memberId: Long, @RequestBody updateRequest: UpdateMemberRequest): ResponseEntity<MemberResponse>{
+    fun updateMember(@AuthenticationPrincipal memberPrincipal: MemberPrincipal, @RequestBody updateRequest: UpdateMemberRequest): ResponseEntity<MemberResponse>{
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(memberService.updateMember(updateRequest))
+            .body(memberService.updateMember(memberPrincipal.id,updateRequest))
     }
 
     @PutMapping("/{memberId}/withdraw")
-    fun withdrawMember(@PathVariable memberId: Long): ResponseEntity<Unit>{
+    fun withdrawMember(@AuthenticationPrincipal memberPrincipal: MemberPrincipal): ResponseEntity<Unit>{
         return ResponseEntity.status(HttpStatus.OK)
-            .body(memberService.withdrawMember(memberId))
+            .body(memberService.withdrawMember(memberPrincipal.id))
     }
 
     @GetMapping

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/UpdateMemberRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/request/UpdateMemberRequest.kt
@@ -8,7 +8,7 @@ data class UpdateMemberRequest(
     val name: String,
     val email: String,
     val password: String,
-    val confirmPassword: String? = null,
+    val newPassword: String? = null,
 ){
     //fun to()= Member(role,nickname,name,email,password)
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
@@ -82,7 +82,7 @@ class MemberService(
         }
 
         if (!passwordEncoder.matches(request.password, foundMember.password)) {
-            if (request.confirmPassword == null || !passwordEncoder.matches(request.password, request.confirmPassword)) {
+            if (request.newPassword == null || !passwordEncoder.matches(request.password, request.newPassword)) {
                 throw IllegalArgumentException("Passwords do not match")
             }
             foundMember.password = passwordEncoder.encode(request.password)

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/MemberService.kt
@@ -1,5 +1,7 @@
 package org.team.b6.catchtable.domain.member.service
 
+import org.intellij.lang.annotations.Pattern
+import org.springframework.boot.fromApplication
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -29,6 +31,9 @@ class MemberService(
 ) {
 
     fun signUp(request: SignupMemberRequest): MemberResponse {
+ //       isValidNickname(request.nickname)
+//        isValidPassword(request.password)
+
         if (memberRepository.existsByEmail(request.email)) {
             throw IllegalStateException("Email is already in use")
         }
@@ -58,23 +63,26 @@ class MemberService(
 
         return LoginResponse(
             accessToken = jwtPlugin.generateAccessToken(
-                subject = member.id.toString(), email = member.email, role = member.role.name
+                subject = member.id.toString(),
+                email = member.email,
+                role = member.role.name
             )
         )
     }
-
-    fun updateMember(request: UpdateMemberRequest): MemberResponse {
+    fun updateMember(memberId: Long,request: UpdateMemberRequest): MemberResponse {
+        val foundIdMember = memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("member")
         val foundMember = memberRepository.findByEmail(request.email) ?: throw ModelNotFoundException("member")
+
+        if(foundIdMember != foundMember){
+            throw InvalidCredentialException("Member")
+        }
 
         if (foundMember.nickname != request.nickname && memberRepository.existsByNickname(request.nickname)) {
             throw IllegalStateException("Nickname is already in use")
         }
 
         if (!passwordEncoder.matches(request.password, foundMember.password)) {
-            if (request.confirmPassword == null || !passwordEncoder.matches(
-                    request.password, request.confirmPassword
-                )
-            ) {
+            if (request.confirmPassword == null || !passwordEncoder.matches(request.password, request.confirmPassword)) {
                 throw IllegalArgumentException("Passwords do not match")
             }
             foundMember.password = passwordEncoder.encode(request.password)
@@ -119,7 +127,8 @@ class MemberService(
     }
 
     fun getMember(id: Long): MemberResponse {
-        val foundMember = memberRepository.findByIdOrNull(id) ?: throw ModelNotFoundException("member")
+        val foundMember = memberRepository.findByIdOrNull(id)
+            ?: throw ModelNotFoundException("member")
         return MemberResponse.from(foundMember)
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#87 

## 작업 내용

- [ ] 기존 @Pathvariable에서 @AuthenticationPrincipal로 인증단계를 변경했습니다.
- [ ] 추가로 updateRequest도 명확성을 위해 confirmPassword의 명칭을 newPassword로 변경했습니다.

## 리뷰 요구사항 (선택)

