### PR TITLE
[Feat] OWNER의 리뷰 삭제 요청을 ADMIN이 승인/거절하는 로직 구현 Part2

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
@@ -16,6 +16,10 @@ class AdminController(
     fun findAllStoreRequirements() =
         ResponseEntity.ok().body(adminService.findAllStoreRequirements())
 
+    @GetMapping("/reviews")
+    fun findAllReviewDeleteRequirements() =
+        ResponseEntity.ok().body(adminService.findAllReviewDeleteRequirements())
+
     @PostMapping("/stores/{storeId}/success")
     fun acceptStoreRequirement(@PathVariable storeId: Long) =
         ResponseEntity.ok().body(adminService.handleStoreRequirement(storeId, true))

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -7,8 +7,11 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.team.b6.catchtable.domain.member.dto.request.SignupMemberRequest
 import org.team.b6.catchtable.domain.member.repository.MemberRepository
+import org.team.b6.catchtable.domain.review.dto.response.ReviewResponse
 import org.team.b6.catchtable.domain.review.model.Review
+import org.team.b6.catchtable.domain.review.model.ReviewStatus
 import org.team.b6.catchtable.domain.review.repository.ReviewRepository
+import org.team.b6.catchtable.domain.store.dto.response.StoreResponse
 import org.team.b6.catchtable.domain.store.model.StoreStatus
 import org.team.b6.catchtable.global.service.GlobalService
 import org.team.b6.catchtable.global.variable.Variables
@@ -24,7 +27,15 @@ class AdminService(
 ) {
     // ADMIN이 처리해야 하는 요구사항들을 조회
     fun findAllStoreRequirements() =
-        globalService.getAllStores().filter { unavailableToReservation(it.status) }
+        globalService.getAllStores()
+            .filter { unavailableToReservation(it.status) }
+            .map { StoreResponse.from(it, globalService.getMember(it.belongTo)) }
+
+    // ADMIN이 처리해야 하는 리뷰 삭제 요구사항들을 조회
+    fun findAllReviewDeleteRequirements() =
+        globalService.getAllReviews()
+            .filter { it.status == ReviewStatus.REQUIRED_FOR_DELETE }
+            .map { ReviewResponse.from(it) }
 
     // 식당 관련 요구사항들을 승인 혹은 거절 (식당 등록 및 삭제 요청)
     fun handleStoreRequirement(storeId: Long, isAccepted: Boolean) =

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/controller/ReviewController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/controller/ReviewController.kt
@@ -56,4 +56,14 @@ class ReviewController(
         reviewService.deleteReview(memberPrincipal, storeId, reviewId)
         return ResponseEntity.noContent().build()
     }
+
+    @PreAuthorize("hasRole('OWNER')")
+    @PostMapping("/{reviewId}")
+    fun requireForDeleteReview(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+        @PathVariable storeId: Long,
+        @PathVariable reviewId: Long
+    ) {
+        reviewService.requireForDeleteReview(memberPrincipal, storeId, reviewId)
+    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/model/Review.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/model/Review.kt
@@ -28,8 +28,15 @@ class Review(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
+    @Column(name = "status")
+    var status = ReviewStatus.OK
+
     fun update(request: ReviewRequest) {
         this.content = request.content
         this.ratings = request.ratings
+    }
+
+    fun updateStatus(status: ReviewStatus) {
+        this.status = status
     }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/model/ReviewStatus.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/model/ReviewStatus.kt
@@ -1,0 +1,5 @@
+package org.team.b6.catchtable.domain.review.model
+
+enum class ReviewStatus {
+    OK, REQUIRED_FOR_DELETE
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional
 import org.team.b6.catchtable.domain.review.dto.request.ReviewRequest
 import org.team.b6.catchtable.domain.review.dto.response.ReviewResponse
 import org.team.b6.catchtable.domain.review.model.Review
+import org.team.b6.catchtable.domain.review.model.ReviewStatus
 import org.team.b6.catchtable.domain.review.repository.ReviewRepository
 import org.team.b6.catchtable.global.exception.EtiquetteException
 import org.team.b6.catchtable.global.exception.InvalidRoleException
@@ -54,6 +55,14 @@ class ReviewService(
             reviewRepository.delete(it)
         }
 
+    // 리뷰 삭제 요청 (OWNER)
+    fun requireForDeleteReview(memberPrincipal: MemberPrincipal, storeId: Long, reviewId: Long) {
+        globalService.getReview(reviewId).let {
+            validateOwner(it, memberPrincipal.id)
+            it.updateStatus(ReviewStatus.REQUIRED_FOR_DELETE)
+        }
+    }
+
     // 리뷰 내용에 욕설이 포함된 경우 등록 불가
     private fun validateContent(content: String) {
         if (Variables.BANNED_WORD_LIST.any { content.contains(it) })
@@ -74,5 +83,10 @@ class ReviewService(
     // 리뷰 수정이 가능한지 확인 (해당 리뷰를 본인이 작성했는지)
     private fun availableToDeleteComment(review: Review, memberId: Long) {
         if (review.member.id != memberId) throw InvalidRoleException("Delete Review")
+    }
+
+    // 리뷰 삭제 요청이 가능한지 확인 (요청의 주체가 리뷰가 달린 식당의 주인인지)
+    private fun validateOwner(review: Review, memberId: Long) {
+        if (review.member.id != memberId) throw InvalidRoleException("Require for Delete Review")
     }
 }


### PR DESCRIPTION
## 연관된 이슈

#101 

## 작업 내용

- [ ] Review 엔티티에 status 속성 추가 (OK, REQUIRED_FOR_DELETE)
- [ ] ReviewController와 ReviewService에 requireForDeleteReview 메서드 생성
    - 요청의 주체가 리뷰가 달린 식당의 주인인지 검증 후, status를 REQUIRED_FOR_DELETE로 변경
- [ ] AdminController와 AdminService에 findAllReviewDeleteRequirements 메서드 생성
    - ADMIN이 처리해야 하는 리뷰 삭제 요구사항들을 조회하는 메서드
