### PR TITLE
[Feat] BlackList 엔티티 생성 Part1

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/blacklist/entity/BlackList.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/blacklist/entity/BlackList.kt
@@ -1,0 +1,37 @@
+package org.team.b6.catchtable.domain.blacklist.entity
+
+import jakarta.persistence.*
+import org.team.b6.catchtable.domain.member.model.Member
+import org.team.b6.catchtable.domain.member.model.MemberRole
+import org.team.b6.catchtable.global.service.UtilService
+import org.team.b6.catchtable.global.variable.Variables
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "BlackList")
+class BlackList(
+    @Column(name = "subject", nullable = false)
+    val subject: Long, // 대상
+
+    @Column(name = "reason", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val reason: BlackListReason, // 사유
+) {
+    @Id
+    @Column(name = "store_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    fun addWarnings(member: Member, utilService: UtilService) {
+        member.numberOfWarnings++
+        if (member.numberOfWarnings % 3 == 0){
+            member.bannedExpiration = LocalDateTime.now().plusDays(7)
+//            member.role = MemberRole.BANNED
+            utilService.sendMail(
+                email = member.email,
+                subject = Variables.MAIL_SUBJECT_BANNED,
+                text = Variables.MAIL_CONTENT_BANNED
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/blacklist/entity/BlackListReason.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/blacklist/entity/BlackListReason.kt
@@ -1,0 +1,5 @@
+package org.team.b6.catchtable.domain.blacklist.entity
+
+enum class BlackListReason {
+    NO_SHOW, TROLLING_REVIEW
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/blacklist/repository/BlackListRepository.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/blacklist/repository/BlackListRepository.kt
@@ -1,0 +1,6 @@
+package org.team.b6.catchtable.domain.blacklist.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.team.b6.catchtable.domain.blacklist.entity.BlackList
+
+interface BlackListRepository : JpaRepository<BlackList, Long>

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/model/Member.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/model/Member.kt
@@ -2,6 +2,7 @@ package org.team.b6.catchtable.domain.member.model
 
 import jakarta.persistence.*
 import org.team.b6.catchtable.global.entity.BaseEntity
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "Members")
@@ -23,11 +24,16 @@ class Member(
     var password: String,
 
     @Column(name = "is_deleted", nullable = false)
-    var isDeleted: Boolean = false
-
+    var isDeleted: Boolean = false,
 ) : BaseEntity() {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
+
+    @Column(name = "number_of_warnings", nullable = false)
+    var numberOfWarnings: Int = 0// 경고 누적 횟수
+
+    @Column(name = "banned_expiration")
+    var bannedExpiration: LocalDateTime? = null // 계정 정지 만료일
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -1,10 +1,11 @@
 package org.team.b6.catchtable.domain.member.service
 
-import org.springframework.mail.javamail.JavaMailSender
-import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.team.b6.catchtable.domain.blacklist.entity.BlackList
+import org.team.b6.catchtable.domain.blacklist.entity.BlackListReason
+import org.team.b6.catchtable.domain.blacklist.repository.BlackListRepository
 import org.team.b6.catchtable.domain.member.dto.request.SignupMemberRequest
 import org.team.b6.catchtable.domain.member.repository.MemberRepository
 import org.team.b6.catchtable.domain.review.dto.response.ReviewResponse
@@ -14,16 +15,18 @@ import org.team.b6.catchtable.domain.review.repository.ReviewRepository
 import org.team.b6.catchtable.domain.store.dto.response.StoreResponse
 import org.team.b6.catchtable.domain.store.model.StoreStatus
 import org.team.b6.catchtable.global.service.GlobalService
+import org.team.b6.catchtable.global.service.UtilService
 import org.team.b6.catchtable.global.variable.Variables
 
 @Service
 @Transactional
 class AdminService(
     private val globalService: GlobalService,
-    private val javaMailSender: JavaMailSender,
+    private val utilService: UtilService,
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder, // TODO : 추후 삭제 (테스트용)
-    private val reviewRepository: ReviewRepository
+    private val reviewRepository: ReviewRepository,
+    private val blackListRepository: BlackListRepository
 ) {
     // ADMIN이 처리해야 하는 요구사항들을 조회
     fun findAllStoreRequirements() =
@@ -49,13 +52,13 @@ class AdminService(
             when (it.status) {
                 StoreStatus.WAITING_FOR_CREATE -> {
                     if (isAccepted) {
-                        sendMail(
+                        utilService.sendMail(
                             email = globalService.getMember(it.belongTo).email,
                             subject = Variables.MAIL_SUBJECT_ACCEPTED,
                             text = Variables.MAIL_CONTENT_STORE_CREATE_ACCEPTED
                         )
                         it.updateStatus(StoreStatus.OK)
-                    } else sendMail(
+                    } else utilService.sendMail(
                         email = globalService.getMember(it.belongTo).email,
                         subject = Variables.MAIL_SUBJECT_REFUSED,
                         text = Variables.MAIL_CONTENT_STORE_CREATE_REFUSED
@@ -64,14 +67,14 @@ class AdminService(
 
                 StoreStatus.WAITING_FOR_DELETE -> {
                     if (isAccepted) {
-                        sendMail(
+                        utilService.sendMail(
                             email = globalService.getMember(it.belongTo).email,
                             subject = Variables.MAIL_SUBJECT_ACCEPTED,
                             text = Variables.MAIL_CONTENT_STORE_DELETE_ACCEPTED
                         )
                         it.updateForDelete()
                         deleteAllComments(it.id!!)
-                    } else sendMail(
+                    } else utilService.sendMail(
                         email = globalService.getMember(it.belongTo).email,
                         subject = Variables.MAIL_SUBJECT_REFUSED,
                         text = Variables.MAIL_CONTENT_STORE_DELETE_REFUSED
@@ -87,20 +90,25 @@ class AdminService(
     fun handleReviewRequirement(reviewId: Long, isAccepted: Boolean) {
         val review = globalService.getReview(reviewId)
         if (isAccepted) {
-            sendMail( // OWNER
+            utilService.sendMail( // OWNER
                 email = globalService.getMember(review.store.belongTo).email,
                 subject = Variables.MAIL_SUBJECT_ACCEPTED,
                 text = Variables.MAIL_CONTENT_REVIEW_DELETE_ACCEPTED
             )
-            sendMail( // USER
+            utilService.sendMail( // USER
                 email = review.member.email,
                 subject = Variables.MAIL_SUBJECT_WARN,
                 text = Variables.MAIL_CONTENT_REVIEW_WARN + additionalMailContent(review)
             )
-            // TODO : 해당 멤버를 Blacklist에 추가하는 로직도 추가해야함
+            val blacklist = BlackList(
+                subject = review.member.id!!,
+                reason = BlackListReason.TROLLING_REVIEW
+            )
+            blackListRepository.save(blacklist)
+            blacklist.addWarnings(review.member, utilService)
             reviewRepository.delete(review)
         } else {
-            sendMail(
+            utilService.sendMail(
                 email = globalService.getMember(review.store.belongTo).email,
                 subject = Variables.MAIL_SUBJECT_REFUSED,
                 text = Variables.MAIL_CONTENT_REVIEW_DELETE_REFUSED
@@ -111,17 +119,6 @@ class AdminService(
     // TODO: 추후 삭제 (테스트용)
     fun registerAdmin(request: SignupMemberRequest) =
         memberRepository.save(request.to(passwordEncoder))
-
-    // [내부 메서드] 메일 전송 기능
-    private fun sendMail(email: String, subject: String, text: String) =
-        javaMailSender.createMimeMessage().let {
-            MimeMessageHelper(it, false).let { helper ->
-                helper.setTo(email)
-                helper.setSubject(subject)
-                helper.setText(text)
-            }
-            javaMailSender.send(it)
-        }
 
     // [내부 메서드] Store가 예약 가능하지 않은 상태인 경우를 판단
     private fun unavailableToReservation(status: StoreStatus) =

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
@@ -91,6 +91,6 @@ class ReviewService(
 
     // 리뷰 삭제 요청이 가능한지 확인 (요청의 주체가 리뷰가 달린 식당의 주인인지)
     private fun validateOwner(review: Review, memberId: Long) {
-        if (review.member.id != memberId) throw InvalidRoleException("Require for Delete Review")
+        if (review.store.belongTo != memberId) throw InvalidRoleException("Require for Delete Review")
     }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/global/exception/InvalidRoleException.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/exception/InvalidRoleException.kt
@@ -6,6 +6,7 @@ class InvalidRoleException(value: String) :
             "Add Review" -> "해당 식당에 예약 이력이 없습니다."
             "Update Review" -> "해당 리뷰의 작성자만 리뷰 수정이 가능합니다."
             "Delete Review" -> "해당 리뷰의 작성자만 리뷰 삭제가 가능합니다."
+            "Require for Delete Review" -> "해당 식당의 소유자만 리뷰 삭제 요청이 가능합니다."
             else -> ""
         }
     )

--- a/src/main/kotlin/org/team/b6/catchtable/global/service/UtilService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/service/UtilService.kt
@@ -1,0 +1,20 @@
+package org.team.b6.catchtable.global.service
+
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.stereotype.Service
+
+@Service
+class UtilService(
+    private val javaMailSender: JavaMailSender
+) {
+    fun sendMail(email: String, subject: String, text: String) =
+        javaMailSender.createMimeMessage().let {
+            MimeMessageHelper(it, false).let { helper ->
+                helper.setTo(email)
+                helper.setSubject(subject)
+                helper.setText(text)
+            }
+            javaMailSender.send(it)
+        }
+}

--- a/src/main/kotlin/org/team/b6/catchtable/global/variable/Variables.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/variable/Variables.kt
@@ -6,13 +6,16 @@ object Variables {
     const val MAIL_SUBJECT_ACCEPTED = "[캐치테이블] 사장님의 요청이 정상적으로 승인되었습니다."
     const val MAIL_SUBJECT_REFUSED = "[캐치테이블] 사장님의 요청이 아쉽게도 거절되었습니다."
     const val MAIL_SUBJECT_WARN = "[캐치테이블] 회원님이 작성한 리뷰가 삭제 처리되었습니다."
+    const val MAIL_SUBJECT_BANNED = "[캐치테이블] 회원님의 계정이 7일 간 사용 정지됩니다."
 
     const val MAIL_CONTENT_STORE_CREATE_ACCEPTED = "식당 등록이 완료되었습니다. 캐치 테이블의 소중한 일원이 되신 것을 환영합니다!"
     const val MAIL_CONTENT_STORE_DELETE_ACCEPTED = "식당 삭제가 완료되었습니다. 다음에 또 볼 수 있는 기회가 있었으면 좋겠습니다ㅠㅠ"
     const val MAIL_CONTENT_STORE_CREATE_REFUSED = "식당 등록이 거절되었습니다. 자세한 사유는 고객센터(1234-5678)로 연락주세요."
     const val MAIL_CONTENT_STORE_DELETE_REFUSED = "식당이 정상적으로 삭제되지 않았습니다. 자세한 사유는 고객센터(1234-5678)을 통해 확인해주세요."
 
-    const val MAIL_CONTENT_REVIEW_DELETE_ACCEPTED = "리뷰 삭제가 완료되었습니다. 해당 유저에게는 경고 1회가 부여하였고, 경고 3회 누적 시 애플리케이션 이용이 제한될 예정입니다."
+    const val MAIL_CONTENT_REVIEW_DELETE_ACCEPTED = "리뷰 삭제가 완료되었습니다. 해당 유저에게 경고 1회가 부여되었고, 경고 3회 누적 시 애플리케이션 이용이 제한될 예정입니다."
     const val MAIL_CONTENT_REVIEW_DELETE_REFUSED = "리뷰 삭제 요청이 거절되었습니다. 자세한 사유는 고객센터(1234-5678)로 연락주세요."
     const val MAIL_CONTENT_REVIEW_WARN = "회원님이 아래와 같이 작성한 리뷰가 악의성 리뷰로 판단되어 삭제 처리되었습니다. 회원님께는 경고 1회가 부여되며, 경고 3회 누적 시 애플리케이션 이용이 제한됩니다."
+
+    const val MAIL_CONTENT_BANNED = "캐치테이블 운영 정책 3회 위반으로 인해 회원님의 계정이 7일 간 애플리케이션 사용이 정지됩니다. 자세한 문의는 고객센터(1234-5678)를 통해 연락주세요."
 }


### PR DESCRIPTION
## 연관된 이슈

#107 

## 작업 내용

- [ ] BlackList 엔티티 생성
    - BlackListReason(경고 사유) enum 클래스 생성 (TROLLING_REVIEW, NO_SHOW)
- [ ] 경고 3번 누적인 경우 7일동안 계정을 사용할 수 없도록 정책 추가
    - 해당 멤버에게 이메일을 전송하여 정지 사실을 알림
    - Variables에 계정 정지 시 메일 제목/내용 추가
- [ ] Member 엔티티에 numberOfWarnings(경고 누적 횟수)와 bannedExpiration(계정 정지 만료일) 속성 추가
- [ ] 메일을 전송하는 sendMail 메서드를 AdminService 내부가 아닌 (글로벌한) UtilService로 이동
- [ ] 기존 GlobalService의 이름을 FindingEntityService로 변경
- [ ] InvalidRoleException에 버그를 발견하여 수정 (단순 Exception 메시지 표기 누락)

## 리뷰 요구사항 (선택)

이슈 규모가 너무 커져서 두 개의 파트로 나눠서 올릴 예정입니다!
