### PR TITLE
[Refactor] ReviewRequest에서 memberId를 받지 않도록 설정

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/dto/request/ReviewRequest.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/dto/request/ReviewRequest.kt
@@ -5,7 +5,6 @@ import org.team.b6.catchtable.domain.review.model.Review
 import org.team.b6.catchtable.domain.store.model.Store
 
 data class ReviewRequest(
-    val memberId: Long,
     val content: String,
     val ratings: Int
 ) {

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
@@ -35,7 +35,7 @@ class ReviewService(
         validateContent(request.content)
         reviewRepository.save(
             request.to(
-                member = globalService.getMember(request.memberId),
+                member = globalService.getMember(memberPrincipal.id),
                 store = globalService.getStore(storeId)
             )
         ).id


### PR DESCRIPTION
## 연관된 이슈

#109 

## 작업 내용

- [ ] ReviewRequest에서 memberId를 제거
- [ ] (memberId가 필요한) ReviewController의 일부 메서드에서 memberPrincipal을 활용하여 로그인한 USER의 id를 받아옴
