### PR TITLE
[Refactor] Store 조회 시 하위 Review가 조회되지 않던 버그 수정

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -33,8 +33,10 @@ class AdminService(
                 StoreResponse.from(
                     store = it,
                     member = globalService.getMember(it.belongTo),
-                    reviews = globalService.getAllReviewsByStoreId(it.id!!)
-                        .map { review -> ReviewResponse.from(review) })
+                    reviews = globalService.getAllReviews()
+                        .filter { review -> review.store.id == it.id }
+                        .map { review -> ReviewResponse.from(review) }
+                )
             }
 
     // ADMIN이 처리해야 하는 리뷰 삭제 요구사항들을 조회

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/repository/ReviewRepository.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/repository/ReviewRepository.kt
@@ -3,6 +3,4 @@ package org.team.b6.catchtable.domain.review.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.team.b6.catchtable.domain.review.model.Review
 
-interface ReviewRepository : JpaRepository<Review, Long> {
-    fun getAllByStoreId(storeId: Long): List<Review>
-}
+interface ReviewRepository : JpaRepository<Review, Long>

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -29,7 +29,8 @@ class StoreService(
                 StoreResponse.from(
                     store = it,
                     member = globalService.getMember(it.belongTo),
-                    reviews = globalService.getAllReviewsByStoreId(it.id!!)
+                    reviews = globalService.getAllReviews()
+                        .filter { review -> review.store.id == it.id }
                         .map { review -> ReviewResponse.from(review) }
                 )
             }
@@ -48,7 +49,8 @@ class StoreService(
             StoreResponse.from(
                 store = it,
                 member = globalService.getMember(it.belongTo),
-                reviews = globalService.getAllReviewsByStoreId(it.id!!)
+                reviews = globalService.getAllReviews()
+                    .filter { review -> review.store.id == it.id }
                     .map { review -> ReviewResponse.from(review) }
             )
         }
@@ -89,7 +91,8 @@ class StoreService(
                 StoreResponse.from(
                     store = it,
                     member = globalService.getMember(it.belongTo),
-                    reviews = globalService.getAllReviewsByStoreId(it.id!!)
+                    reviews = globalService.getAllReviews()
+                        .filter { review -> review.store.id == it.id }
                         .map { review -> ReviewResponse.from(review) }
                 )
             }

--- a/src/main/kotlin/org/team/b6/catchtable/global/service/GlobalService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/service/GlobalService.kt
@@ -31,8 +31,6 @@ class GlobalService(
 
     fun getAllReviews(): MutableList<Review> = reviewRepository.findAll()
 
-    fun getAllReviewsByStoreId(storeId: Long) = reviewRepository.getAllByStoreId(storeId)
-
     fun getReview(reviewId: Long) =
         reviewRepository.findByIdOrNull(reviewId) ?: throw ModelNotFoundException("리뷰")
 


### PR DESCRIPTION
## 연관된 이슈

#111 

## 작업 내용

- ReviewRepository의 getAllByStoreId 메서드 제거 (JPA 명명 규칙 오류)
- filter를 통해 storeId를 비교하는 것으로 변경
