### PR TITLE
[Feat] BlackList 엔티티 생성 Part2

### DIFF
--- a/src/main/kotlin/org/team/b6/catchtable/CatchTableApplication.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/CatchTableApplication.kt
@@ -3,9 +3,11 @@ package org.team.b6.catchtable
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 class CatchTableApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/controller/AdminController.kt
@@ -8,7 +8,7 @@ import org.team.b6.catchtable.domain.member.service.AdminService
 
 @RestController
 @RequestMapping("/admins")
-@PreAuthorize("hasRole('ADMIN')")
+//@PreAuthorize("hasRole('ADMIN')")
 class AdminController(
     private val adminService: AdminService
 ) {
@@ -19,6 +19,10 @@ class AdminController(
     @GetMapping("/reviews")
     fun findAllReviewDeleteRequirements() =
         ResponseEntity.ok().body(adminService.findAllReviewDeleteRequirements())
+
+    @GetMapping("/banned-members")
+    fun findAllBannedMembers() =
+        ResponseEntity.ok().body(adminService.findAllBannedMembers())
 
     @PostMapping("/stores/{storeId}/success")
     fun acceptStoreRequirement(@PathVariable storeId: Long) =

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/BannedMemberResponse.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/dto/response/BannedMemberResponse.kt
@@ -1,0 +1,29 @@
+package org.team.b6.catchtable.domain.member.dto.response
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import org.team.b6.catchtable.domain.blacklist.entity.BlackList
+import org.team.b6.catchtable.domain.blacklist.entity.BlackListReason
+import org.team.b6.catchtable.domain.member.model.Member
+import org.team.b6.catchtable.domain.member.model.MemberRole
+import java.time.LocalDateTime
+
+data class BannedMemberResponse(
+    val role: MemberRole,
+    val nickname: String,
+    val name: String,
+    val email: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    val until: LocalDateTime,
+    val reasons: String
+) {
+    companion object {
+        fun from(member: Member, reasons: String) = BannedMemberResponse(
+            role = member.role,
+            nickname = member.nickname,
+            name = member.name,
+            email = member.email,
+            until = member.bannedExpiration!!,
+            reasons = reasons
+        )
+    }
+}

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/model/Member.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/model/Member.kt
@@ -32,8 +32,12 @@ class Member(
     val id: Long? = null
 
     @Column(name = "number_of_warnings", nullable = false)
-    var numberOfWarnings: Int = 0// 경고 누적 횟수
+    var numberOfWarnings: Int = 0 // 경고 누적 횟수
 
     @Column(name = "banned_expiration")
     var bannedExpiration: LocalDateTime? = null // 계정 정지 만료일
+
+    fun liftSuspension() {
+        this.bannedExpiration = null
+    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -1,5 +1,6 @@
 package org.team.b6.catchtable.domain.member.service
 
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,6 +31,14 @@ class AdminService(
     private val reviewRepository: ReviewRepository,
     private val blackListRepository: BlackListRepository
 ) {
+    // 계정 정지가 만료된 회원을 10초에 한 번씩 확인
+    @Scheduled(fixedDelay = 1000 * 10)
+    fun liftSuspension(){
+        findingEntityService.getAllMembers()
+            .filter { it.bannedExpiration != null && it.bannedExpiration!! < LocalDateTime.now()}
+            .map { it.liftSuspension() }
+    }
+
     // ADMIN이 처리해야 하는 요구사항들을 조회
     fun findAllStoreRequirements() =
         findingEntityService.getAllStores()

--- a/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/member/service/AdminService.kt
@@ -7,6 +7,7 @@ import org.team.b6.catchtable.domain.blacklist.entity.BlackList
 import org.team.b6.catchtable.domain.blacklist.entity.BlackListReason
 import org.team.b6.catchtable.domain.blacklist.repository.BlackListRepository
 import org.team.b6.catchtable.domain.member.dto.request.SignupMemberRequest
+import org.team.b6.catchtable.domain.member.dto.response.BannedMemberResponse
 import org.team.b6.catchtable.domain.member.repository.MemberRepository
 import org.team.b6.catchtable.domain.review.dto.response.ReviewResponse
 import org.team.b6.catchtable.domain.review.model.Review
@@ -14,14 +15,15 @@ import org.team.b6.catchtable.domain.review.model.ReviewStatus
 import org.team.b6.catchtable.domain.review.repository.ReviewRepository
 import org.team.b6.catchtable.domain.store.dto.response.StoreResponse
 import org.team.b6.catchtable.domain.store.model.StoreStatus
-import org.team.b6.catchtable.global.service.GlobalService
+import org.team.b6.catchtable.global.service.FindingEntityService
 import org.team.b6.catchtable.global.service.UtilService
 import org.team.b6.catchtable.global.variable.Variables
+import java.time.LocalDateTime
 
 @Service
 @Transactional
 class AdminService(
-    private val globalService: GlobalService,
+    private val findingEntityService: FindingEntityService,
     private val utilService: UtilService,
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder, // TODO : 추후 삭제 (테스트용)
@@ -30,13 +32,13 @@ class AdminService(
 ) {
     // ADMIN이 처리해야 하는 요구사항들을 조회
     fun findAllStoreRequirements() =
-        globalService.getAllStores()
+        findingEntityService.getAllStores()
             .filter { unavailableToReservation(it.status) }
             .map {
                 StoreResponse.from(
                     store = it,
-                    member = globalService.getMember(it.belongTo),
-                    reviews = globalService.getAllReviews()
+                    member = findingEntityService.getMember(it.belongTo),
+                    reviews = findingEntityService.getAllReviews()
                         .filter { review -> review.store.id == it.id }
                         .map { review -> ReviewResponse.from(review) }
                 )
@@ -44,24 +46,38 @@ class AdminService(
 
     // ADMIN이 처리해야 하는 리뷰 삭제 요구사항들을 조회
     fun findAllReviewDeleteRequirements() =
-        globalService.getAllReviews()
+        findingEntityService.getAllReviews()
             .filter { it.status == ReviewStatus.REQUIRED_FOR_DELETE }
             .map { ReviewResponse.from(it) }
 
+    // 현재 계정이 정지된 USER 목록을 조회
+    fun findAllBannedMembers() =
+        findingEntityService.getAllMembers()
+            .filter { it.bannedExpiration != null && it.bannedExpiration!! > LocalDateTime.now() }
+            .map {
+                BannedMemberResponse.from(
+                    member = it,
+                    reasons = findingEntityService.getAllBlackLists()
+                        .filter { blacklist -> blacklist.subject == it.id }
+                        .map { blacklist -> blacklist.reason.name }
+                        .toSet().joinToString(" ")
+                )
+            }
+
     // 식당 관련 요구사항들을 승인 혹은 거절 (식당 등록 및 삭제 요청)
     fun handleStoreRequirement(storeId: Long, isAccepted: Boolean) =
-        globalService.getStore(storeId).let {
+        findingEntityService.getStore(storeId).let {
             when (it.status) {
                 StoreStatus.WAITING_FOR_CREATE -> {
                     if (isAccepted) {
                         utilService.sendMail(
-                            email = globalService.getMember(it.belongTo).email,
+                            email = findingEntityService.getMember(it.belongTo).email,
                             subject = Variables.MAIL_SUBJECT_ACCEPTED,
                             text = Variables.MAIL_CONTENT_STORE_CREATE_ACCEPTED
                         )
                         it.updateStatus(StoreStatus.OK)
                     } else utilService.sendMail(
-                        email = globalService.getMember(it.belongTo).email,
+                        email = findingEntityService.getMember(it.belongTo).email,
                         subject = Variables.MAIL_SUBJECT_REFUSED,
                         text = Variables.MAIL_CONTENT_STORE_CREATE_REFUSED
                     )
@@ -70,14 +86,14 @@ class AdminService(
                 StoreStatus.WAITING_FOR_DELETE -> {
                     if (isAccepted) {
                         utilService.sendMail(
-                            email = globalService.getMember(it.belongTo).email,
+                            email = findingEntityService.getMember(it.belongTo).email,
                             subject = Variables.MAIL_SUBJECT_ACCEPTED,
                             text = Variables.MAIL_CONTENT_STORE_DELETE_ACCEPTED
                         )
                         it.updateForDelete()
                         deleteAllComments(it.id!!)
                     } else utilService.sendMail(
-                        email = globalService.getMember(it.belongTo).email,
+                        email = findingEntityService.getMember(it.belongTo).email,
                         subject = Variables.MAIL_SUBJECT_REFUSED,
                         text = Variables.MAIL_CONTENT_STORE_DELETE_REFUSED
                     )
@@ -90,10 +106,10 @@ class AdminService(
 
     // 리뷰 관련 요구사항들을 승인 혹은 거절 (리뷰 삭제 요청)
     fun handleReviewRequirement(reviewId: Long, isAccepted: Boolean) {
-        val review = globalService.getReview(reviewId)
+        val review = findingEntityService.getReview(reviewId)
         if (isAccepted) {
             utilService.sendMail( // OWNER
-                email = globalService.getMember(review.store.belongTo).email,
+                email = findingEntityService.getMember(review.store.belongTo).email,
                 subject = Variables.MAIL_SUBJECT_ACCEPTED,
                 text = Variables.MAIL_CONTENT_REVIEW_DELETE_ACCEPTED
             )
@@ -111,7 +127,7 @@ class AdminService(
             reviewRepository.delete(review)
         } else {
             utilService.sendMail(
-                email = globalService.getMember(review.store.belongTo).email,
+                email = findingEntityService.getMember(review.store.belongTo).email,
                 subject = Variables.MAIL_SUBJECT_REFUSED,
                 text = Variables.MAIL_CONTENT_REVIEW_DELETE_REFUSED
             )

--- a/src/main/kotlin/org/team/b6/catchtable/domain/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/reservation/service/ReservationServiceImpl.kt
@@ -3,6 +3,7 @@ package org.team.b6.catchtable.domain.reservation.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.team.b6.catchtable.domain.member.model.Member
 import org.team.b6.catchtable.domain.member.repository.MemberRepository
 import org.team.b6.catchtable.domain.reservation.dto.ReservationRequest
 import org.team.b6.catchtable.domain.reservation.dto.ReservationResponse
@@ -11,6 +12,7 @@ import org.team.b6.catchtable.domain.reservation.model.ReservationStatus
 import org.team.b6.catchtable.domain.reservation.model.toResponse
 import org.team.b6.catchtable.domain.reservation.repository.ReservationRepository
 import org.team.b6.catchtable.domain.store.repository.StoreRepository
+import org.team.b6.catchtable.global.exception.BannedUserException
 import org.team.b6.catchtable.global.exception.ModelNotFoundException
 import org.team.b6.catchtable.global.security.MemberPrincipal
 
@@ -29,6 +31,7 @@ class ReservationServiceImpl(
     ): ReservationResponse {
         val member = memberRepository.findByIdOrNull(memberPrincipal.id) ?: throw ModelNotFoundException("modelName")
         val store = storeRepository.findByIdOrNull(storeId) ?: throw ModelNotFoundException("modelName")
+        validateBannedExpiration(member)
         return reservationRepository.save(
             Reservation(
                 member = member,
@@ -101,4 +104,8 @@ class ReservationServiceImpl(
         }
     }
 
+    private fun validateBannedExpiration(member: Member) {
+        if (member.bannedExpiration != null)
+            throw BannedUserException(member.bannedExpiration!!)
+    }
 }

--- a/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/review/service/ReviewService.kt
@@ -8,26 +8,27 @@ import org.team.b6.catchtable.domain.review.model.Review
 import org.team.b6.catchtable.domain.review.model.ReviewStatus
 import org.team.b6.catchtable.domain.review.repository.ReviewRepository
 import org.team.b6.catchtable.domain.store.model.StoreStatus
+import org.team.b6.catchtable.global.exception.BannedUserException
 import org.team.b6.catchtable.global.exception.EtiquetteException
 import org.team.b6.catchtable.global.exception.InvalidRoleException
 import org.team.b6.catchtable.global.exception.StoreRequirementDeniedException
 import org.team.b6.catchtable.global.security.MemberPrincipal
-import org.team.b6.catchtable.global.service.GlobalService
+import org.team.b6.catchtable.global.service.FindingEntityService
 import org.team.b6.catchtable.global.variable.Variables
 
 @Service
 @Transactional
 class ReviewService(
     private val reviewRepository: ReviewRepository,
-    private val globalService: GlobalService
+    private val findingEntityService: FindingEntityService
 ) {
     // 전체 리뷰 조회
     fun findReviews(storeId: Long) =
-        globalService.getAllReviews().filter { it.store.id == storeId }.map { ReviewResponse.from(it) }
+        findingEntityService.getAllReviews().filter { it.store.id == storeId }.map { ReviewResponse.from(it) }
 
     // 단일 리뷰 조회
     fun findReview(storeId: Long, reviewId: Long) =
-        ReviewResponse.from(globalService.getReview(reviewId))
+        ReviewResponse.from(findingEntityService.getReview(reviewId))
 
     // 리뷰 등록
     fun addReview(memberPrincipal: MemberPrincipal, storeId: Long, request: ReviewRequest) {
@@ -35,8 +36,8 @@ class ReviewService(
         validateContent(request.content)
         reviewRepository.save(
             request.to(
-                member = globalService.getMember(memberPrincipal.id),
-                store = globalService.getStore(storeId)
+                member = findingEntityService.getMember(memberPrincipal.id),
+                store = findingEntityService.getStore(storeId)
             )
         ).id
     }
@@ -44,7 +45,7 @@ class ReviewService(
     // 리뷰 수정
     fun updateReview(memberPrincipal: MemberPrincipal, storeId: Long, reviewId: Long, request: ReviewRequest) {
         validateContent(request.content)
-        globalService.getReview(reviewId).let {
+        findingEntityService.getReview(reviewId).let {
             availableToUpdateComment(it, memberPrincipal.id)
             it.update(request)
         }
@@ -52,14 +53,14 @@ class ReviewService(
 
     // 리뷰 삭제
     fun deleteReview(memberPrincipal: MemberPrincipal, storeId: Long, reviewId: Long) =
-        globalService.getReview(reviewId).let {
+        findingEntityService.getReview(reviewId).let {
             availableToDeleteComment(it, memberPrincipal.id)
             reviewRepository.delete(it)
         }
 
     // 리뷰 삭제 요청 (OWNER)
     fun requireForDeleteReview(memberPrincipal: MemberPrincipal, storeId: Long, reviewId: Long) {
-        globalService.getReview(reviewId).let {
+        findingEntityService.getReview(reviewId).let {
             validateOwner(it, memberPrincipal.id)
             it.updateStatus(ReviewStatus.REQUIRED_FOR_DELETE)
         }
@@ -71,12 +72,14 @@ class ReviewService(
             throw EtiquetteException()
     }
 
-    // 리뷰 등록이 가능한지 확인 (해당 식당에 예약 이력이 있는지 + 식당이 예약 가능한 상태인지)
+    // 리뷰 등록이 가능한지 확인 (해당 식당에 예약 이력이 있는지 + 식당이 예약 가능한 상태인지 + 계정 정지 여부 확인)
     private fun availableToAddComment(memberId: Long, storeId: Long) {
-        if (!globalService.getAllReservations().any { it.store.id == storeId && it.member.id == memberId })
+        if (!findingEntityService.getAllReservations().any { it.store.id == storeId && it.member.id == memberId })
             throw InvalidRoleException("Add Review")
-        else if (globalService.getStore(storeId).status != StoreStatus.OK)
+        else if (findingEntityService.getStore(storeId).status != StoreStatus.OK)
             throw StoreRequirementDeniedException("review")
+        else if (findingEntityService.getMember(memberId).bannedExpiration != null)
+            throw BannedUserException(findingEntityService.getMember(memberId).bannedExpiration!!)
     }
 
     // 리뷰 수정이 가능한지 확인 (해당 리뷰를 본인이 작성했는지)

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/StoreService.kt
@@ -12,14 +12,14 @@ import org.team.b6.catchtable.domain.store.model.StoreStatus
 import org.team.b6.catchtable.domain.store.repository.StoreRepository
 import org.team.b6.catchtable.global.exception.*
 import org.team.b6.catchtable.global.security.MemberPrincipal
-import org.team.b6.catchtable.global.service.GlobalService
+import org.team.b6.catchtable.global.service.FindingEntityService
 
 @Service
 @Transactional
 class StoreService(
     private val storeRepository: StoreRepository,
     private val reservationRepository: ReservationRepository,
-    private val globalService: GlobalService
+    private val findingEntityService: FindingEntityService
 ) {
     // 카테고리 별 식당 전체 조회
     fun findAllStoresByCategory(category: String) =
@@ -28,8 +28,8 @@ class StoreService(
             .map {
                 StoreResponse.from(
                     store = it,
-                    member = globalService.getMember(it.belongTo),
-                    reviews = globalService.getAllReviews()
+                    member = findingEntityService.getMember(it.belongTo),
+                    reviews = findingEntityService.getAllReviews()
                         .filter { review -> review.store.id == it.id }
                         .map { review -> ReviewResponse.from(review) }
                 )
@@ -45,11 +45,11 @@ class StoreService(
 
     // 식당 단일 조회
     fun findStore(storeId: Long) =
-        globalService.getStore(storeId).let {
+        findingEntityService.getStore(storeId).let {
             StoreResponse.from(
                 store = it,
-                member = globalService.getMember(it.belongTo),
-                reviews = globalService.getAllReviews()
+                member = findingEntityService.getMember(it.belongTo),
+                reviews = findingEntityService.getAllReviews()
                     .filter { review -> review.store.id == it.id }
                     .map { review -> ReviewResponse.from(review) }
             )
@@ -64,7 +64,7 @@ class StoreService(
     // 식당 정보 수정
     fun updateStore(storeId: Long, request: StoreRequest) {
         validateDuplicationInUpdate(request.name, request.address, storeId)
-        globalService.getStore(storeId)
+        findingEntityService.getStore(storeId)
             .let {
                 validateStoreStatus(it)
                 it.update(request)
@@ -73,7 +73,7 @@ class StoreService(
 
     // 식당 삭제 신청
     fun deleteStore(storeId: Long) =
-        globalService.getStore(storeId).updateStatus(StoreStatus.WAITING_FOR_DELETE)
+        findingEntityService.getStore(storeId).updateStatus(StoreStatus.WAITING_FOR_DELETE)
 
     // 카테고리에 대한 유효성 검사
     private fun getCategory(category: String) =
@@ -90,8 +90,8 @@ class StoreService(
             .map {
                 StoreResponse.from(
                     store = it,
-                    member = globalService.getMember(it.belongTo),
-                    reviews = globalService.getAllReviews()
+                    member = findingEntityService.getMember(it.belongTo),
+                    reviews = findingEntityService.getAllReviews()
                         .filter { review -> review.store.id == it.id }
                         .map { review -> ReviewResponse.from(review) }
                 )

--- a/src/main/kotlin/org/team/b6/catchtable/domain/store/service/TimeTableService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/domain/store/service/TimeTableService.kt
@@ -5,13 +5,13 @@
 //import org.springframework.transaction.annotation.Transactional
 //import org.team.b6.catchtable.domain.store.dto.request.TimeTableRequest
 //import org.team.b6.catchtable.domain.store.repository.TimeTableRepository
-//import org.team.b6.catchtable.global.service.GlobalService
+//import org.team.b6.catchtable.global.service.FindingEntityService
 //
 //@Service
 //@Transactional
 //class TimeTableService(
 //    val timeTableRepository: TimeTableRepository,
-//    val globalService: GlobalService
+//    val globalService: FindingEntityService
 //) {
 //    // 초기 타임 테이블 세팅
 //    fun setTimeTable(storeId: Long, request: TimeTableRequest) {

--- a/src/main/kotlin/org/team/b6/catchtable/global/exception/BannedUserException.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/exception/BannedUserException.kt
@@ -1,0 +1,8 @@
+package org.team.b6.catchtable.global.exception
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class BannedUserException(until: LocalDateTime) : RuntimeException(
+    "${until.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))}까지 계정이 정지되어, 해당 기능을 사용할 수 없습니다."
+)

--- a/src/main/kotlin/org/team/b6/catchtable/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/exception/GlobalExceptionHandler.kt
@@ -103,6 +103,16 @@ class GlobalExceptionHandler(
             )
         )
 
+    @ExceptionHandler(BannedUserException::class)
+    fun handleBannedUserException(e: BannedUserException) =
+        ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+            ErrorResponse(
+                httpStatus = "403 Forbidden",
+                message = e.message.toString(),
+                path = httpServletRequest.requestURI
+            )
+        )
+
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException) =
         ResponseEntity.badRequest().body(

--- a/src/main/kotlin/org/team/b6/catchtable/global/service/FindingEntityService.kt
+++ b/src/main/kotlin/org/team/b6/catchtable/global/service/FindingEntityService.kt
@@ -2,6 +2,8 @@ package org.team.b6.catchtable.global.service
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.team.b6.catchtable.domain.blacklist.entity.BlackList
+import org.team.b6.catchtable.domain.blacklist.repository.BlackListRepository
 import org.team.b6.catchtable.domain.member.model.Member
 import org.team.b6.catchtable.domain.member.repository.MemberRepository
 import org.team.b6.catchtable.domain.reservation.model.Reservation
@@ -13,11 +15,12 @@ import org.team.b6.catchtable.domain.store.repository.StoreRepository
 import org.team.b6.catchtable.global.exception.ModelNotFoundException
 
 @Service
-class GlobalService(
+class FindingEntityService(
     private val memberRepository: MemberRepository,
     private val storeRepository: StoreRepository,
     private val reviewRepository: ReviewRepository,
-    private val reservationRepository: ReservationRepository
+    private val reservationRepository: ReservationRepository,
+    private val blackListRepository: BlackListRepository
 ) {
     fun getAllMembers(): MutableList<Member> = memberRepository.findAll()
 
@@ -38,4 +41,6 @@ class GlobalService(
 
     fun getReservation(reservationId: Long) =
         reservationRepository.findByIdOrNull(reservationId) ?: throw ModelNotFoundException("예약")
+
+    fun getAllBlackLists(): MutableList<BlackList> = blackListRepository.findAll()
 }


### PR DESCRIPTION
## 연관된 이슈

#113 

## 작업 내용

- [ ] 리뷰 등록 및 식당 예약 시 계정 정지 여부를 확인하는 로직 추가
- [ ] ADMIN 페이지에서 현재 계정이 정지된 회원 목록을 확인
    - AdminController, AdminService에 findAllBannedMembers 메서드 추가
    - BannedMemberResponse 클래스를 생성하여 리턴값 조정
- [ ] 예외 케이스 추가 (BannedUserException)
- [ ] 10초에 한번씩 계정 정지된 회원을 조회하여 기한이 만료되면 다시 풀어주는 기능 구현
    - AdminService에서 Scheduled 어노테이션을 활용
    - Member 엔티티에 liftSuspension 메서드를 생성하여 계정 정지 기간이 종료되면 USER의 banned_expiriation이 null로 변경
